### PR TITLE
Added method ORTB2GetDevicetype to Device

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,7 @@
+1.32.0 - January 26, 2026
+
+added method ORTB2GetDevicetype to Device struct
+
 1.31.0 - June 2025
 
 - complete new error managment that will allow to use errors.Is() for

--- a/wurfl.go
+++ b/wurfl.go
@@ -90,6 +90,19 @@ const (
 	WurflUpdaterFrequencyWeekly = C.WURFL_UPDATER_FREQ_WEEKLY
 )
 
+// ORTB2 device types derived from ORTB 2.6 specification
+const (
+	ORTB2DeviceTypeUnknown          = 0 // Unknown
+	ORTB2DeviceTypeMobileTablet     = 1 // Mobile/Tablet - General
+	ORTB2DeviceTypePersonalComputer = 2 // Personal Computer
+	ORTB2DeviceTypeConnectedTV      = 3 // Connected TV
+	ORTB2DeviceTypePhone            = 4 // Phone
+	ORTB2DeviceTypeTablet           = 5 // Tablet
+	ORTB2DeviceTypeConnectedDevice  = 6 // Connected Device
+	ORTB2DeviceTypeSetTopBox        = 7 // Set Top Box
+	ORTB2DeviceTypeOOH              = 8 // OOH Device
+)
+
 // HeaderQuality represents the header quality value
 type HeaderQuality int
 
@@ -175,6 +188,7 @@ type DeviceHandler interface {
 	GetOriginalUserAgent() (string, error)
 	GetUserAgent() (string, error)
 	Destroy()
+	ORTB2GetDevicetype() (int, error)
 }
 
 // Updater defines API methods for the Updater
@@ -191,7 +205,7 @@ type Updater interface {
 }
 
 // Version is the current version of this package.
-const Version = "1.31.0"
+const Version = "1.32.0"
 
 // APIVersion returns version of internal InFuze API without an initialized engine
 func APIVersion() string {
@@ -1133,6 +1147,73 @@ func (d *Device) Destroy() {
 	if d.Device != nil {
 		C.wurfl_device_destroy(d.Device)
 		d.Device = nil
+	}
+}
+
+// ORTB2GetDevicetype returns the ORTB2 device type based on WURFL capabilities.
+// Device types are derived from ORTB 2.6 specification (see ORTB2DeviceType* constants).
+// If some capabilities are missing, the function continues checking the remaining ones
+// and returns an error listing all missing capabilities only if the result is Unknown.
+//
+// Required static capabilities: is_ott, is_console, physical_form_factor
+// Required virtual capabilities: form_factor
+func (d *Device) ORTB2GetDevicetype() (int, error) {
+	var missingCaps []string
+
+	// Priority 1: Check is_ott (static capability)
+	if isOTT, err := d.GetStaticCap("is_ott"); err == nil {
+		if isOTT == "true" {
+			return ORTB2DeviceTypeSetTopBox, nil
+		}
+	} else {
+		missingCaps = append(missingCaps, "is_ott")
+	}
+
+	// Priority 2: Check is_console (static capability)
+	if isConsole, err := d.GetStaticCap("is_console"); err == nil {
+		if isConsole == "true" {
+			return ORTB2DeviceTypeConnectedDevice, nil
+		}
+	} else {
+		missingCaps = append(missingCaps, "is_console")
+	}
+
+	// Priority 3: Check physical_form_factor for out_of_home_device (static capability)
+	if physicalFormFactor, err := d.GetStaticCap("physical_form_factor"); err == nil {
+		if physicalFormFactor == "out_of_home_device" {
+			return ORTB2DeviceTypeOOH, nil
+		}
+	} else {
+		missingCaps = append(missingCaps, "physical_form_factor")
+	}
+
+	// Priority 4: Check form_factor (virtual capability)
+	formFactor, err := d.GetVirtualCap("form_factor")
+	if err != nil {
+		missingCaps = append(missingCaps, "form_factor")
+		// form_factor not available, return unknown with error listing all missing capabilities
+		return ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
+	}
+
+	switch formFactor {
+	case "Desktop":
+		return ORTB2DeviceTypePersonalComputer, nil
+	case "Smartphone", "Feature Phone":
+		return ORTB2DeviceTypePhone, nil
+	case "Tablet":
+		return ORTB2DeviceTypeTablet, nil
+	case "Smart-TV":
+		return ORTB2DeviceTypeConnectedTV, nil
+	case "Other non-Mobile", "Robot":
+		return ORTB2DeviceTypeConnectedDevice, nil
+	case "Other Mobile":
+		return ORTB2DeviceTypeMobileTablet, nil
+	default:
+		// Unknown form_factor, return unknown with error if there were missing capabilities
+		if len(missingCaps) > 0 {
+			return ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
+		}
+		return ORTB2DeviceTypeUnknown, nil
 	}
 }
 

--- a/wurfl.go
+++ b/wurfl.go
@@ -16,6 +16,7 @@ package wurfl
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -1158,41 +1159,30 @@ func (d *Device) Destroy() {
 // Required static capabilities: is_ott, is_console, physical_form_factor
 // Required virtual capabilities: form_factor
 func (d *Device) ORTB2GetDevicetype() (int, error) {
-	var missingCaps []string
+	errMissingCaps := "this method requires is_ott, is_console, physical_form_factor static caps and form_factor virtual cap"
+
+	// Check that required capabilities are available
+	isOTT, errOtt := d.GetStaticCap("is_ott")
+	isConsole, errConsole := d.GetStaticCap("is_console")
+	physicalFormFactor, errPFF := d.GetStaticCap("physical_form_factor")
+	formFactor, errFF := d.GetVirtualCap("form_factor")
+	if errOtt != nil || errConsole != nil || errPFF != nil || errFF != nil {
+		return ORTB2DeviceTypeUnknown, errors.New("ORTB2GetDevicetype: " + errMissingCaps)
+	}
 
 	// Priority 1: Check is_ott (static capability)
-	if isOTT, err := d.GetStaticCap("is_ott"); err == nil {
-		if isOTT == "true" {
-			return ORTB2DeviceTypeSetTopBox, nil
-		}
-	} else {
-		missingCaps = append(missingCaps, "is_ott")
+	if isOTT == "true" {
+		return ORTB2DeviceTypeSetTopBox, nil
 	}
 
 	// Priority 2: Check is_console (static capability)
-	if isConsole, err := d.GetStaticCap("is_console"); err == nil {
-		if isConsole == "true" {
-			return ORTB2DeviceTypeConnectedDevice, nil
-		}
-	} else {
-		missingCaps = append(missingCaps, "is_console")
+	if isConsole == "true" {
+		return ORTB2DeviceTypeConnectedDevice, nil
 	}
 
 	// Priority 3: Check physical_form_factor for out_of_home_device (static capability)
-	if physicalFormFactor, err := d.GetStaticCap("physical_form_factor"); err == nil {
-		if physicalFormFactor == "out_of_home_device" {
-			return ORTB2DeviceTypeOOH, nil
-		}
-	} else {
-		missingCaps = append(missingCaps, "physical_form_factor")
-	}
-
-	// Priority 4: Check form_factor (virtual capability)
-	formFactor, err := d.GetVirtualCap("form_factor")
-	if err != nil {
-		missingCaps = append(missingCaps, "form_factor")
-		// form_factor not available, return unknown with error listing all missing capabilities
-		return ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
+	if physicalFormFactor == "out_of_home_device" {
+		return ORTB2DeviceTypeOOH, nil
 	}
 
 	switch formFactor {
@@ -1209,10 +1199,7 @@ func (d *Device) ORTB2GetDevicetype() (int, error) {
 	case "Other Mobile":
 		return ORTB2DeviceTypeMobileTablet, nil
 	default:
-		// Unknown form_factor, return unknown with error if there were missing capabilities
-		if len(missingCaps) > 0 {
-			return ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
-		}
+		// Unknown form_factor
 		return ORTB2DeviceTypeUnknown, nil
 	}
 }

--- a/wurfl.go
+++ b/wurfl.go
@@ -1153,8 +1153,8 @@ func (d *Device) Destroy() {
 
 // ORTB2GetDevicetype returns the ORTB2 device type based on WURFL capabilities.
 // Device types are derived from ORTB 2.6 specification (see ORTB2DeviceType* constants).
-// If some capabilities are missing, the function continues checking the remaining ones
-// and returns an error listing all missing capabilities only if the result is Unknown.
+// If some capabilities are missing, the function returns Unknown
+// and an error listing the needed capabilities.
 //
 // Required static capabilities: is_ott, is_console, physical_form_factor
 // Required virtual capabilities: form_factor

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1735,322 +1734,80 @@ func TestGetVirtualCaps(t *testing.T) {
 	})
 }
 
-// The Device handler can be mocked implementing the DeviceHandler interface.
-// Below is a simple mock that does not require external dependencies.
-type MockDevice struct {
-	staticCaps  map[string]string
-	virtualCaps map[string]string
-}
-
-func (m *MockDevice) GetMatchType() int {
-	return 0
-}
-func (m *MockDevice) GetVirtualCapabilities(caps []string) map[string]string {
-	return m.virtualCaps
-}
-func (m *MockDevice) GetVirtualCaps(caps []string) (map[string]string, error) {
-	return m.virtualCaps, nil
-}
-func (m *MockDevice) GetVirtualCapability(vcap string) string {
-	return m.virtualCaps[vcap]
-}
-func (m *MockDevice) GetVirtualCap(vcap string) (string, error) {
-	if val, ok := m.virtualCaps[vcap]; ok {
-		return val, nil
-	}
-	return "", fmt.Errorf("%s : specified virtual capability is missing", vcap)
-}
-func (m *MockDevice) GetVirtualCapabilityAsInt(vcap string) (int, error) {
-	return 0, nil
-}
-func (m *MockDevice) GetCapabilities(caps []string) map[string]string {
-	return m.staticCaps
-}
-func (m *MockDevice) GetStaticCaps(caps []string) (map[string]string, error) {
-	return m.staticCaps, nil
-}
-func (m *MockDevice) GetCapability(cap string) string {
-	return m.staticCaps[cap]
-}
-func (m *MockDevice) GetStaticCap(cap string) (string, error) {
-	if val, ok := m.staticCaps[cap]; ok {
-		return val, nil
-	}
-	return "", fmt.Errorf("%s : specified capability is missing", cap)
-}
-func (m *MockDevice) GetCapabilityAsInt(cap string) (int, error) {
-	return 0, nil
-}
-func (m *MockDevice) IsRoot() bool {
-	return false
-}
-func (m *MockDevice) GetRootID() string {
-	return ""
-}
-func (m *MockDevice) GetParentID() string {
-	return ""
-}
-func (m *MockDevice) GetDeviceID() (string, error) {
-	return "mock_device", nil
-}
-func (m *MockDevice) GetNormalizedUserAgent() (string, error) {
-	return "", nil
-}
-func (m *MockDevice) GetOriginalUserAgent() (string, error) {
-	return "", nil
-}
-func (m *MockDevice) GetUserAgent() (string, error) {
-	return "", nil
-}
-func (m *MockDevice) Destroy() {
-}
-func (m *MockDevice) ORTB2GetDevicetype() (int, error) {
-	var missingCaps []string
-
-	// Priority 1: Check is_ott (static capability)
-	if isOTT, err := m.GetStaticCap("is_ott"); err == nil {
-		if isOTT == "true" {
-			return wurfl.ORTB2DeviceTypeSetTopBox, nil
-		}
-	} else {
-		missingCaps = append(missingCaps, "is_ott")
-	}
-
-	// Priority 2: Check is_console (static capability)
-	if isConsole, err := m.GetStaticCap("is_console"); err == nil {
-		if isConsole == "true" {
-			return wurfl.ORTB2DeviceTypeConnectedDevice, nil
-		}
-	} else {
-		missingCaps = append(missingCaps, "is_console")
-	}
-
-	// Priority 3: Check physical_form_factor for out_of_home_device (static capability)
-	if physicalFormFactor, err := m.GetStaticCap("physical_form_factor"); err == nil {
-		if physicalFormFactor == "out_of_home_device" {
-			return wurfl.ORTB2DeviceTypeOOH, nil
-		}
-	} else {
-		missingCaps = append(missingCaps, "physical_form_factor")
-	}
-
-	// Priority 4: Check form_factor (virtual capability)
-	formFactor, err := m.GetVirtualCap("form_factor")
-	if err != nil {
-		missingCaps = append(missingCaps, "form_factor")
-		return wurfl.ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
-	}
-
-	switch formFactor {
-	case "Desktop":
-		return wurfl.ORTB2DeviceTypePersonalComputer, nil
-	case "Smartphone", "Feature Phone":
-		return wurfl.ORTB2DeviceTypePhone, nil
-	case "Tablet":
-		return wurfl.ORTB2DeviceTypeTablet, nil
-	case "Smart-TV":
-		return wurfl.ORTB2DeviceTypeConnectedTV, nil
-	case "Other non-Mobile", "Robot":
-		return wurfl.ORTB2DeviceTypeConnectedDevice, nil
-	case "Other Mobile":
-		return wurfl.ORTB2DeviceTypeMobileTablet, nil
-	default:
-		if len(missingCaps) > 0 {
-			return wurfl.ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
-		}
-		return wurfl.ORTB2DeviceTypeUnknown, nil
-	}
-}
-
 func Test_ORTB2GetDevicetype(t *testing.T) {
+	wengine := fixtureCreateEngine(t)
+	require.NotNil(t, wengine)
+	defer wengine.Destroy()
+
+	// Check if all required capabilities are available
+	requiredStaticCaps := []string{"is_ott", "is_console", "physical_form_factor"}
+	requiredVirtualCaps := []string{"form_factor"}
+
+	hasAllCaps := true
+	for _, cap := range requiredStaticCaps {
+		if !wengine.HasCapability(cap) {
+			hasAllCaps = false
+			break
+		}
+	}
+	for _, vcap := range requiredVirtualCaps {
+		if !wengine.HasVirtualCapability(vcap) {
+			hasAllCaps = false
+			break
+		}
+	}
+
+	if !hasAllCaps {
+		// Test that method returns error when capabilities are missing
+		t.Run("Missing capabilities", func(t *testing.T) {
+			ua := "Mozilla/5.0 (Linux; Android 13; ONIX Build/TP1A.220624.014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.7559.59 Mobile Safari/537.36"
+			device, err := wengine.LookupUserAgent(ua)
+			require.NoError(t, err)
+			defer device.Destroy()
+
+			_, err = device.ORTB2GetDevicetype()
+			assert.Error(t, err, "ORTB2GetDevicetype should return error when capabilities are missing")
+			assert.Contains(t, err.Error(), "this method requires")
+		})
+		return
+	}
+
+	// All capabilities available, test with real user agents
 	tests := []struct {
-		name        string
-		staticCaps  map[string]string
-		virtualCaps map[string]string
-		expected    int
-		wantErr     bool
+		name     string
+		ua       string
+		expected int
 	}{
 		{
-			name: "Mobile phone",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "phone_phablet",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Smartphone",
-			},
+			name:     "Smartphone",
+			ua:       "Mozilla/5.0 (Linux; Android 13; ONIX Build/TP1A.220624.014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.7559.59 Mobile Safari/537.36",
 			expected: wurfl.ORTB2DeviceTypePhone,
 		},
 		{
-			name: "Tablet",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "tablet_slate",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Tablet",
-			},
+			name:     "Tablet",
+			ua:       "Mozilla/5.0 (Linux; Android 16; SM-X400 Build/BP2A.250605.031.A3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/143.0.7499.143 Safari/537.36",
 			expected: wurfl.ORTB2DeviceTypeTablet,
 		},
 		{
-			name: "Smart TV",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "screen_smart_tv",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Smart-TV",
-			},
-			expected: wurfl.ORTB2DeviceTypeConnectedTV,
-		},
-		{
-			name: "Console",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "true",
-				"physical_form_factor": "screen_game_console",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Other non-Mobile",
-			},
-			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
-		},
-		{
-			name: "Desktop - Windows Brave",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "computer",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Desktop",
-			},
+			name:     "Desktop",
+			ua:       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/126.0.6448.0 Safari/537.36",
 			expected: wurfl.ORTB2DeviceTypePersonalComputer,
 		},
 		{
-			name: "Set Top Box - OTT device",
-			staticCaps: map[string]string{
-				"is_ott":               "true",
-				"is_console":           "false",
-				"physical_form_factor": "screen_connected_device",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Other non-Mobile",
-			},
-			expected: wurfl.ORTB2DeviceTypeSetTopBox,
-		},
-		{
-			name: "OOH - Out of Home device",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "out_of_home_device",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Other non-Mobile",
-			},
-			expected: wurfl.ORTB2DeviceTypeOOH,
-		},
-		{
-			name: "Other Mobile device",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "other",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Other Mobile",
-			},
-			expected: wurfl.ORTB2DeviceTypeMobileTablet,
-		},
-		{
-			name: "Feature phone",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "phone_bar",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Feature Phone",
-			},
-			expected: wurfl.ORTB2DeviceTypePhone,
-		},
-		{
-			name: "Robot",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "other",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Robot",
-			},
+			name:     "Console",
+			ua:       "Mozilla/5.0 (PlayStation Vita 3.73) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2 VTE/3.73",
 			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
-		},
-		{
-			name: "Other non-Mobile device",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "connected_device",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Other non-Mobile",
-			},
-			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
-			wantErr:  false,
-		},
-		{
-			name: "Missing physical_form_factor but form_factor available",
-			staticCaps: map[string]string{
-				"is_ott":     "false",
-				"is_console": "false",
-			},
-			virtualCaps: map[string]string{
-				"form_factor": "Smartphone",
-			},
-			expected: wurfl.ORTB2DeviceTypePhone,
-			wantErr:  false,
-		},
-		{
-			name: "Missing form_factor capability",
-			staticCaps: map[string]string{
-				"is_ott":               "false",
-				"is_console":           "false",
-				"physical_form_factor": "computer",
-			},
-			virtualCaps: map[string]string{},
-			expected:    wurfl.ORTB2DeviceTypeUnknown,
-			wantErr:     true,
-		},
-		{
-			name: "Missing multiple capabilities",
-			staticCaps: map[string]string{
-				"is_ott": "false",
-			},
-			virtualCaps: map[string]string{},
-			expected:    wurfl.ORTB2DeviceTypeUnknown,
-			wantErr:     true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockDevice := &MockDevice{
-				staticCaps:  tt.staticCaps,
-				virtualCaps: tt.virtualCaps,
-			}
+			device, err := wengine.LookupUserAgent(tt.ua)
+			require.NoError(t, err)
+			defer device.Destroy()
 
-			got, err := mockDevice.ORTB2GetDevicetype()
-			if tt.wantErr {
-				assert.Error(t, err, "ORTB2GetDevicetype expected an error")
-				assert.Contains(t, err.Error(), "missing capabilities")
-			} else {
-				assert.NoErrorf(t, err, "ORTB2GetDevicetype error: %v", err)
-			}
+			got, err := device.ORTB2GetDevicetype()
+			assert.NoError(t, err, "ORTB2GetDevicetype should not return error")
 			assert.Equal(t, tt.expected, got, "ORTB2GetDevicetype() = %d, want %d", got, tt.expected)
 		})
 	}

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1732,6 +1733,327 @@ func TestGetVirtualCaps(t *testing.T) {
 			t.Errorf("Expected %d capabilities, got %d", len(caps)-1, len(result))
 		}
 	})
+}
+
+// The Device handler can be mocked implementing the DeviceHandler interface.
+// Below is a simple mock that does not require external dependencies.
+type MockDevice struct {
+	staticCaps  map[string]string
+	virtualCaps map[string]string
+}
+
+func (m *MockDevice) GetMatchType() int {
+	return 0
+}
+func (m *MockDevice) GetVirtualCapabilities(caps []string) map[string]string {
+	return m.virtualCaps
+}
+func (m *MockDevice) GetVirtualCaps(caps []string) (map[string]string, error) {
+	return m.virtualCaps, nil
+}
+func (m *MockDevice) GetVirtualCapability(vcap string) string {
+	return m.virtualCaps[vcap]
+}
+func (m *MockDevice) GetVirtualCap(vcap string) (string, error) {
+	if val, ok := m.virtualCaps[vcap]; ok {
+		return val, nil
+	}
+	return "", fmt.Errorf("%s : specified virtual capability is missing", vcap)
+}
+func (m *MockDevice) GetVirtualCapabilityAsInt(vcap string) (int, error) {
+	return 0, nil
+}
+func (m *MockDevice) GetCapabilities(caps []string) map[string]string {
+	return m.staticCaps
+}
+func (m *MockDevice) GetStaticCaps(caps []string) (map[string]string, error) {
+	return m.staticCaps, nil
+}
+func (m *MockDevice) GetCapability(cap string) string {
+	return m.staticCaps[cap]
+}
+func (m *MockDevice) GetStaticCap(cap string) (string, error) {
+	if val, ok := m.staticCaps[cap]; ok {
+		return val, nil
+	}
+	return "", fmt.Errorf("%s : specified capability is missing", cap)
+}
+func (m *MockDevice) GetCapabilityAsInt(cap string) (int, error) {
+	return 0, nil
+}
+func (m *MockDevice) IsRoot() bool {
+	return false
+}
+func (m *MockDevice) GetRootID() string {
+	return ""
+}
+func (m *MockDevice) GetParentID() string {
+	return ""
+}
+func (m *MockDevice) GetDeviceID() (string, error) {
+	return "mock_device", nil
+}
+func (m *MockDevice) GetNormalizedUserAgent() (string, error) {
+	return "", nil
+}
+func (m *MockDevice) GetOriginalUserAgent() (string, error) {
+	return "", nil
+}
+func (m *MockDevice) GetUserAgent() (string, error) {
+	return "", nil
+}
+func (m *MockDevice) Destroy() {
+}
+func (m *MockDevice) ORTB2GetDevicetype() (int, error) {
+	var missingCaps []string
+
+	// Priority 1: Check is_ott (static capability)
+	if isOTT, err := m.GetStaticCap("is_ott"); err == nil {
+		if isOTT == "true" {
+			return wurfl.ORTB2DeviceTypeSetTopBox, nil
+		}
+	} else {
+		missingCaps = append(missingCaps, "is_ott")
+	}
+
+	// Priority 2: Check is_console (static capability)
+	if isConsole, err := m.GetStaticCap("is_console"); err == nil {
+		if isConsole == "true" {
+			return wurfl.ORTB2DeviceTypeConnectedDevice, nil
+		}
+	} else {
+		missingCaps = append(missingCaps, "is_console")
+	}
+
+	// Priority 3: Check physical_form_factor for out_of_home_device (static capability)
+	if physicalFormFactor, err := m.GetStaticCap("physical_form_factor"); err == nil {
+		if physicalFormFactor == "out_of_home_device" {
+			return wurfl.ORTB2DeviceTypeOOH, nil
+		}
+	} else {
+		missingCaps = append(missingCaps, "physical_form_factor")
+	}
+
+	// Priority 4: Check form_factor (virtual capability)
+	formFactor, err := m.GetVirtualCap("form_factor")
+	if err != nil {
+		missingCaps = append(missingCaps, "form_factor")
+		return wurfl.ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
+	}
+
+	switch formFactor {
+	case "Desktop":
+		return wurfl.ORTB2DeviceTypePersonalComputer, nil
+	case "Smartphone", "Feature Phone":
+		return wurfl.ORTB2DeviceTypePhone, nil
+	case "Tablet":
+		return wurfl.ORTB2DeviceTypeTablet, nil
+	case "Smart-TV":
+		return wurfl.ORTB2DeviceTypeConnectedTV, nil
+	case "Other non-Mobile", "Robot":
+		return wurfl.ORTB2DeviceTypeConnectedDevice, nil
+	case "Other Mobile":
+		return wurfl.ORTB2DeviceTypeMobileTablet, nil
+	default:
+		if len(missingCaps) > 0 {
+			return wurfl.ORTB2DeviceTypeUnknown, fmt.Errorf("ORTB2GetDevicetype: missing capabilities: %s", strings.Join(missingCaps, ", "))
+		}
+		return wurfl.ORTB2DeviceTypeUnknown, nil
+	}
+}
+
+func Test_ORTB2GetDevicetype(t *testing.T) {
+	tests := []struct {
+		name        string
+		staticCaps  map[string]string
+		virtualCaps map[string]string
+		expected    int
+		wantErr     bool
+	}{
+		{
+			name: "Mobile phone",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "phone_phablet",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Smartphone",
+			},
+			expected: wurfl.ORTB2DeviceTypePhone,
+		},
+		{
+			name: "Tablet",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "tablet_slate",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Tablet",
+			},
+			expected: wurfl.ORTB2DeviceTypeTablet,
+		},
+		{
+			name: "Smart TV",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "screen_smart_tv",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Smart-TV",
+			},
+			expected: wurfl.ORTB2DeviceTypeConnectedTV,
+		},
+		{
+			name: "Console",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "true",
+				"physical_form_factor": "screen_game_console",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Other non-Mobile",
+			},
+			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
+		},
+		{
+			name: "Desktop - Windows Brave",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "computer",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Desktop",
+			},
+			expected: wurfl.ORTB2DeviceTypePersonalComputer,
+		},
+		{
+			name: "Set Top Box - OTT device",
+			staticCaps: map[string]string{
+				"is_ott":               "true",
+				"is_console":           "false",
+				"physical_form_factor": "screen_connected_device",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Other non-Mobile",
+			},
+			expected: wurfl.ORTB2DeviceTypeSetTopBox,
+		},
+		{
+			name: "OOH - Out of Home device",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "out_of_home_device",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Other non-Mobile",
+			},
+			expected: wurfl.ORTB2DeviceTypeOOH,
+		},
+		{
+			name: "Other Mobile device",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "other",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Other Mobile",
+			},
+			expected: wurfl.ORTB2DeviceTypeMobileTablet,
+		},
+		{
+			name: "Feature phone",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "phone_bar",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Feature Phone",
+			},
+			expected: wurfl.ORTB2DeviceTypePhone,
+		},
+		{
+			name: "Robot",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "other",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Robot",
+			},
+			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
+		},
+		{
+			name: "Other non-Mobile device",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "connected_device",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Other non-Mobile",
+			},
+			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
+			wantErr:  false,
+		},
+		{
+			name: "Missing physical_form_factor but form_factor available",
+			staticCaps: map[string]string{
+				"is_ott":     "false",
+				"is_console": "false",
+			},
+			virtualCaps: map[string]string{
+				"form_factor": "Smartphone",
+			},
+			expected: wurfl.ORTB2DeviceTypePhone,
+			wantErr:  false,
+		},
+		{
+			name: "Missing form_factor capability",
+			staticCaps: map[string]string{
+				"is_ott":               "false",
+				"is_console":           "false",
+				"physical_form_factor": "computer",
+			},
+			virtualCaps: map[string]string{},
+			expected:    wurfl.ORTB2DeviceTypeUnknown,
+			wantErr:     true,
+		},
+		{
+			name: "Missing multiple capabilities",
+			staticCaps: map[string]string{
+				"is_ott": "false",
+			},
+			virtualCaps: map[string]string{},
+			expected:    wurfl.ORTB2DeviceTypeUnknown,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDevice := &MockDevice{
+				staticCaps:  tt.staticCaps,
+				virtualCaps: tt.virtualCaps,
+			}
+
+			got, err := mockDevice.ORTB2GetDevicetype()
+			if tt.wantErr {
+				assert.Error(t, err, "ORTB2GetDevicetype expected an error")
+				assert.Contains(t, err.Error(), "missing capabilities")
+			} else {
+				assert.NoErrorf(t, err, "ORTB2GetDevicetype error: %v", err)
+			}
+			assert.Equal(t, tt.expected, got, "ORTB2GetDevicetype() = %d, want %d", got, tt.expected)
+		})
+	}
 }
 
 func TestGetLastUpdated(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `ORTB2GetDevicetype()` method to the `Device` struct that returns the ORTB 2.6 device type based on WURFL capabilities
- Add ORTB 2.6 device type constants (`ORTB2DeviceType*`) for all supported device types (0-8)
- Update `DeviceHandler` interface to include the new method
- Bump package version to 1.32.0

## ORTB2 Device Type Mapping

The method maps WURFL capabilities to ORTB 2.6 device types using the following priority:

| Priority | WURFL Capability | Value | ORTB2 Device Type |
|----------|------------------|-------|-------------------|
| 1 | `is_ott` | `true` | Set Top Box (7) |
| 2 | `is_console` | `true` | Connected Device (6) |
| 3 | `physical_form_factor` | `out_of_home_device` | OOH Device (8) |
| 4 | `form_factor` | `Desktop` | Personal Computer (2) |
| 4 | `form_factor` | `Smartphone`, `Feature Phone` | Phone (4) |
| 4 | `form_factor` | `Tablet` | Tablet (5) |
| 4 | `form_factor` | `Smart-TV` | Connected TV (3) |
| 4 | `form_factor` | `Other non-Mobile`, `Robot` | Connected Device (6) |
| 4 | `form_factor` | `Other Mobile` | Mobile/Tablet (1) |
