### PR TITLE
Feat/perf enh

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+1.33.0 - April 7, 2026
+
+- Optimized LookupWithImportantHeaderMap and LookupDeviceIDWithImportantHeaderMap: replaced per-call C.CString allocations for header names with a trie-based lookup using pre-allocated C strings, reducing cgo overhead on hot paths
+- Case-insensitive header name matching now handled via inline bit folding
+- Fixed potential C memory leaks by deferring C.free calls in Create, LookupDeviceIDWithRequest, and LookupDeviceIDWithImportantHeaderMap
+
 1.32.1 - January 26, 2026
 
 - fixed method ORTB2GetDevicetype to Device struct

--- a/bench_test.go
+++ b/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	wurfl "github.com/WURFL/golang-wurfl"
 	"github.com/stretchr/testify/assert"
@@ -969,6 +970,96 @@ func Benchmark_GetAllDeviceIds(b *testing.B) {
 func Benchmark_CStringCFree(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		wurfl.GoStringToCStringAndFree("capability")
+	}
+}
+
+// sink prevents the compiler from optimizing away benchmark results
+var benchSink unsafe.Pointer
+
+func Benchmark_TrieGet(b *testing.B) {
+	headers := []string{
+		"Accept-Encoding", "CAST-DEVICE-CAPABILITIES", "Device-Stock-UA",
+		"Sec-CH-UA", "Sec-CH-UA-Arch", "Sec-CH-UA-Full-Version",
+		"Sec-CH-UA-Full-Version-List", "Sec-CH-UA-Mobile", "Sec-CH-UA-Model",
+		"Sec-CH-UA-Platform", "Sec-CH-UA-Platform-Version", "User-Agent",
+		"X-OperaMini-Phone-UA", "X-Requested-With", "X-UCBrowser-Device-UA",
+	}
+	trieGet := wurfl.BenchmarkableTrieGet(headers)
+
+	b.Run("ExactCase", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchSink = trieGet("Sec-CH-UA-Full-Version-List")
+		}
+	})
+	b.Run("MixedCase", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchSink = trieGet("sEc-cH-uA-fUlL-vErSiOn-LiSt")
+		}
+	})
+	b.Run("NotFound", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchSink = trieGet("X-Not-A-Real-Header")
+		}
+	})
+	b.Run("ShortKey", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchSink = trieGet("User-Agent")
+		}
+	})
+}
+
+// Benchmark_HeaderLookupStrategies compares four strategies for case-insensitive
+// header name lookup using the same set of 15 WURFL important header names.
+//
+// Strategies:
+//   - Trie: | 0x20 byte folding per byte, O(len(key)), 0 allocs
+//   - Map: strings.ToLower + map access, 1 alloc (unavoidable for hashing)
+//   - SequentialEqualFold: linear scan with strings.EqualFold, 0 allocs
+//   - BinarySearchFold: sort.Search with | 0x20 comparator + EqualFold confirm, 0 allocs
+func Benchmark_HeaderLookupStrategies(b *testing.B) {
+	headers := []string{
+		"Accept-Encoding", "CAST-DEVICE-CAPABILITIES", "Device-Stock-UA",
+		"Sec-CH-UA", "Sec-CH-UA-Arch", "Sec-CH-UA-Full-Version",
+		"Sec-CH-UA-Full-Version-List", "Sec-CH-UA-Mobile", "Sec-CH-UA-Model",
+		"Sec-CH-UA-Platform", "Sec-CH-UA-Platform-Version", "User-Agent",
+		"X-OperaMini-Phone-UA", "X-Requested-With", "X-UCBrowser-Device-UA",
+	}
+
+	trieGet := wurfl.BenchmarkableTrieGet(headers)
+	mapGet := wurfl.BenchmarkableMapGet(headers)
+	seqGet := wurfl.BenchmarkableSequentialEqualFoldGet(headers)
+	bsfGet := wurfl.BenchmarkableBinarySearchFoldGet(headers)
+
+	keys := []struct {
+		name string
+		key  string
+	}{
+		{"LongKey_MixedCase", "sEc-cH-uA-fUlL-vErSiOn-LiSt"},
+		{"ShortKey_MixedCase", "uSeR-aGeNt"},
+		{"NotFound", "X-Not-A-Real-Header"},
+	}
+
+	for _, k := range keys {
+		b.Run("Trie/"+k.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				benchSink = trieGet(k.key)
+			}
+		})
+		b.Run("Map/"+k.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				benchSink = mapGet(k.key)
+			}
+		})
+		b.Run("SequentialEqualFold/"+k.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				benchSink = seqGet(k.key)
+			}
+		})
+		b.Run("BinarySearchFold/"+k.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				benchSink = bsfGet(k.key)
+			}
+		})
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1104,7 +1104,7 @@ func TestP99_LookupUserAgent_NoCache(t *testing.T) {
 // used to prevent compiler optimizations in the BenchmarkStringToLower
 var sinkString string
 
-func BenchmarkStringToLower(b *testing.B) {
+func Benchmark_StringToLower(b *testing.B) {
 	headerName := "Sec-CH-UA-Platform-Version"
 
 	b.ResetTimer()

--- a/bench_test.go
+++ b/bench_test.go
@@ -611,10 +611,6 @@ func Benchmark_LookupWithImportantHeaderMap_NoCache(b *testing.B) {
 	IHMap["Sec-CH-UA-Platform"] = "Android"
 	IHMap["Sec-CH-UA-Platform-Version"] = "11"
 	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
-<<<<<<< ihm-lookup-opt-trie
-=======
-
->>>>>>> feat/perf-enh
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1008,14 +1008,15 @@ func Benchmark_TrieGet(b *testing.B) {
 	})
 }
 
-// Benchmark_HeaderLookupStrategies compares four strategies for case-insensitive
+// Benchmark_HeaderLookupStrategies compares two strategies for case-insensitive
 // header name lookup using the same set of 15 WURFL important header names.
 //
 // Strategies:
 //   - Trie: | 0x20 byte folding per byte, O(len(key)), 0 allocs
 //   - Map: strings.ToLower + map access, 1 alloc (unavoidable for hashing)
-//   - SequentialEqualFold: linear scan with strings.EqualFold, 0 allocs
-//   - BinarySearchFold: sort.Search with | 0x20 comparator + EqualFold confirm, 0 allocs
+//
+// Setup (building tries/maps) is done before b.Run, so it's excluded from timing.
+// Each sub-benchmark gets its own timer.
 func Benchmark_HeaderLookupStrategies(b *testing.B) {
 	headers := []string{
 		"Accept-Encoding", "CAST-DEVICE-CAPABILITIES", "Device-Stock-UA",
@@ -1027,8 +1028,6 @@ func Benchmark_HeaderLookupStrategies(b *testing.B) {
 
 	trieGet := wurfl.BenchmarkableTrieGet(headers)
 	mapGet := wurfl.BenchmarkableMapGet(headers)
-	seqGet := wurfl.BenchmarkableSequentialEqualFoldGet(headers)
-	bsfGet := wurfl.BenchmarkableBinarySearchFoldGet(headers)
 
 	keys := []struct {
 		name string
@@ -1048,16 +1047,6 @@ func Benchmark_HeaderLookupStrategies(b *testing.B) {
 		b.Run("Map/"+k.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				benchSink = mapGet(k.key)
-			}
-		})
-		b.Run("SequentialEqualFold/"+k.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				benchSink = seqGet(k.key)
-			}
-		})
-		b.Run("BinarySearchFold/"+k.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				benchSink = bsfGet(k.key)
 			}
 		})
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -567,6 +567,35 @@ func Benchmark_LookupWithImportantHeaderMap_Cache(b *testing.B) {
 	b.StopTimer()
 }
 
+// Benchmark_LookupWithImportantHeaderMap_AllSecChUa_Cache
+func Benchmark_LookupWithImportantHeaderMap_AllSecChUa_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+
+	IHMap := make(map[string]string)
+	IHMap["Accept-Encoding"] = "gzip, br"
+	IHMap["X-Requested-With"] = "com.instagram.android"
+	IHMap["User-Agent"] = UserAgent
+	IHMap["Sec-CH-UA"] = "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\""
+	IHMap["Sec-CH-UA-Full-Version"] = "90.0.4430.91"
+	IHMap["Sec-CH-UA-Platform"] = "Android"
+	IHMap["Sec-CH-UA-Platform-Version"] = "11"
+	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
+	IHMap["Sec-CH-UA-Mobile"] = "?1"
+	IHMap["Sec-CH-UA-Arch"] = "x86"
+	IHMap["Sec-Ch-Ua-Full-Version-List"] = "\"Chromium\";v=\"146.0.7680.157\", \"Not-A.Brand\";v=\"24.0.0.0\", \"Android WebView\";v=\"146.0.7680.157\""
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupWithImportantHeaderMap(IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
 // Benchmark_LookupWithImportantHeaderMap_NoCache
 func Benchmark_LookupWithImportantHeaderMap_NoCache(b *testing.B) {
 	wengine := fixtureCreateEngineCachesize(nil, "")
@@ -580,7 +609,6 @@ func Benchmark_LookupWithImportantHeaderMap_NoCache(b *testing.B) {
 	IHMap["Sec-CH-UA-Platform"] = "Android"
 	IHMap["Sec-CH-UA-Platform-Version"] = "11"
 	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -649,6 +649,46 @@ func BenchmarkGetVirtualCap(b *testing.B) {
 	b.StopTimer()
 }
 
+func TestP99_LookupRequest_NoCache(t *testing.T) {
+	wengine := fixtureCreateEngineCachesize(t, "")
+	defer wengine.Destroy()
+	ua := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("User-Agent", ua)
+	req.Header.Add("Sec-CH-UA", "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\"")
+	req.Header.Add("Sec-CH-UA-Full-Version", "90.0.4430.91")
+	req.Header.Add("Sec-CH-UA-Platform", "Android")
+	req.Header.Add("Sec-CH-UA-Platform-Version", "11")
+	req.Header.Add("Sec-CH-UA-Model", "SM-M315F")
+
+	const iterations = 1000000
+	durations := make([]time.Duration, iterations)
+
+	// warmup
+	for i := 0; i < 100; i++ {
+		device, _ := wengine.LookupRequest(req)
+		device.Destroy()
+	}
+
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		device, _ := wengine.LookupRequest(req)
+		device.Destroy()
+		durations[i] = time.Since(start)
+	}
+
+	slices.Sort(durations)
+	p50 := durations[iterations*50/100]
+	p95 := durations[iterations*95/100]
+	p99 := durations[iterations*99/100]
+	p100 := durations[iterations-1]
+	t.Logf("Iterations: %d", iterations)
+	t.Logf("P50:  %v", p50)
+	t.Logf("P95:  %v", p95)
+	t.Logf("P99:  %v", p99)
+	t.Logf("P100: %v", p100)
+}
+
 func TestP99_LookupUserAgent_NoCache(t *testing.T) {
 	wengine := fixtureCreateEngineCachesize(t, "")
 	defer wengine.Destroy()

--- a/bench_test.go
+++ b/bench_test.go
@@ -2,7 +2,9 @@ package wurfl_test
 
 import (
 	"net/http"
+	"slices"
 	"testing"
+	"time"
 
 	wurfl "github.com/WURFL/golang-wurfl"
 	"github.com/stretchr/testify/assert"
@@ -645,4 +647,37 @@ func BenchmarkGetVirtualCap(b *testing.B) {
 		}
 	}
 	b.StopTimer()
+}
+
+func TestP99_LookupUserAgent_NoCache(t *testing.T) {
+	wengine := fixtureCreateEngineCachesize(t, "")
+	defer wengine.Destroy()
+	ua := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+
+	const iterations = 1000000
+	durations := make([]time.Duration, iterations)
+
+	// warmup
+	for i := 0; i < 1000; i++ {
+		device, _ := wengine.LookupUserAgent(ua)
+		device.Destroy()
+	}
+
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		device, _ := wengine.LookupUserAgent(ua)
+		device.Destroy()
+		durations[i] = time.Since(start)
+	}
+
+	slices.Sort(durations)
+	p50 := durations[iterations*50/100]
+	p95 := durations[iterations*95/100]
+	p99 := durations[iterations*99/100]
+	p100 := durations[iterations-1]
+	t.Logf("Iterations: %d", iterations)
+	t.Logf("P50:  %v", p50)
+	t.Logf("P95:  %v", p95)
+	t.Logf("P99:  %v", p99)
+	t.Logf("P100: %v", p100)
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -567,6 +567,35 @@ func Benchmark_LookupWithImportantHeaderMap_Cache(b *testing.B) {
 	b.StopTimer()
 }
 
+// Benchmark_LookupWithImportantHeaderMap_AllSecChUa_Cache
+func Benchmark_LookupWithImportantHeaderMap_AllSecChUa_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+
+	IHMap := make(map[string]string)
+	IHMap["Accept-Encoding"] = "gzip, br"
+	IHMap["X-Requested-With"] = "com.instagram.android"
+	IHMap["User-Agent"] = UserAgent
+	IHMap["Sec-CH-UA"] = "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\""
+	IHMap["Sec-CH-UA-Full-Version"] = "90.0.4430.91"
+	IHMap["Sec-CH-UA-Platform"] = "Android"
+	IHMap["Sec-CH-UA-Platform-Version"] = "11"
+	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
+	IHMap["Sec-CH-UA-Mobile"] = "?1"
+	IHMap["Sec-CH-UA-Arch"] = "x86"
+	IHMap["Sec-Ch-Ua-Full-Version-List"] = "\"Chromium\";v=\"146.0.7680.157\", \"Not-A.Brand\";v=\"24.0.0.0\", \"Android WebView\";v=\"146.0.7680.157\""
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupWithImportantHeaderMap(IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
 // Benchmark_LookupWithImportantHeaderMap_NoCache
 func Benchmark_LookupWithImportantHeaderMap_NoCache(b *testing.B) {
 	wengine := fixtureCreateEngineCachesize(nil, "")

--- a/bench_test.go
+++ b/bench_test.go
@@ -543,6 +543,356 @@ func Benchmark_LookupRequest_NoCache(b *testing.B) {
 	b.StopTimer()
 }
 
+// Benchmark_LookupWithImportantHeaderMap_Cache
+func Benchmark_LookupWithImportantHeaderMap_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+
+	IHMap := make(map[string]string)
+	IHMap["User-Agent"] = UserAgent
+	IHMap["Sec-CH-UA"] = "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\""
+	IHMap["Sec-CH-UA-Full-Version"] = "90.0.4430.91"
+	IHMap["Sec-CH-UA-Platform"] = "Android"
+	IHMap["Sec-CH-UA-Platform-Version"] = "11"
+	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupWithImportantHeaderMap(IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupWithImportantHeaderMap_NoCache
+func Benchmark_LookupWithImportantHeaderMap_NoCache(b *testing.B) {
+	wengine := fixtureCreateEngineCachesize(nil, "")
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+
+	IHMap := make(map[string]string)
+	IHMap["User-Agent"] = UserAgent
+	IHMap["Sec-CH-UA"] = "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\""
+	IHMap["Sec-CH-UA-Full-Version"] = "90.0.4430.91"
+	IHMap["Sec-CH-UA-Platform"] = "Android"
+	IHMap["Sec-CH-UA-Platform-Version"] = "11"
+	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupWithImportantHeaderMap(IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupRequest_Long_Cache
+func Benchmark_LookupRequest_Long_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 14; XQ-CT54 Build/64.2.A.2.258; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/146.0.7680.157 Mobile Safari/537.36 Instagram 422.0.0.44.64 Android (34/14; 420dpi; 1096x2560; Sony; XQ-CT54; XQ-CT54; qcom; en_GB; 916494010; IABMV/1)"
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("Accept", "*/*")
+	req.Header.Add("Accept-Encoding", "gzip, br")
+	req.Header.Add("Accept-Language", "en-GB,en-US;q=0.9,en;q=0.8")
+	req.Header.Add("Cdn-Loop", "cloudflare; loops=1")
+	req.Header.Add("Cf-Connecting-Ip", "217.216.97.90")
+	req.Header.Add("Cf-Ew-Via", "15")
+	req.Header.Add("Cf-Ipcountry", "DE")
+	req.Header.Add("Cf-Ray", "9e3709414e65a043-FRA")
+	req.Header.Add("Cf-Visitor", "{\"scheme\":\"https\"}")
+	req.Header.Add("Cf-Worker", "html-load.cc")
+	req.Header.Add("Forwarded", "for=217.216.97.90")
+	req.Header.Add("Host", "prebid.wurflcloud.com")
+	req.Header.Add("Referer", "https://vsco.co/")
+	req.Header.Add("Sec-Ch-Ua", "\"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Android WebView\";v=\"146\"")
+	req.Header.Add("Sec-Ch-Ua-Full-Version", "\"146.0.7680.157\"")
+	req.Header.Add("Sec-Ch-Ua-Full-Version-List", "\"Chromium\";v=\"146.0.7680.157\", \"Not-A.Brand\";v=\"24.0.0.0\", \"Android WebView\";v=\"146.0.7680.157\"")
+	req.Header.Add("Sec-Ch-Ua-Mobile", "?1")
+	req.Header.Add("Sec-Ch-Ua-Model", "\"XQ-CT54\"")
+	req.Header.Add("Sec-Ch-Ua-Platform", "\"Android\"")
+	req.Header.Add("Sec-Ch-Ua-Platform-Version", "\"14.0.0\"")
+	req.Header.Add("Sec-Fetch-Dest", "script")
+	req.Header.Add("Sec-Fetch-Mode", "no-cors")
+	req.Header.Add("Sec-Fetch-Site", "cross-site")
+	req.Header.Add("Sec-Fetch-Storage-Access", "active")
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("X-Amzn-Trace-Id", "Root=1-69c7d9dc-618fdb3e4d9456fc38f66cab")
+	req.Header.Add("X-As-Script-Type", "ESSENTIAL")
+	req.Header.Add("X-Device-Accept-Language", "en-GB,en-US;q=0.9,en;q=0.8")
+	req.Header.Add("X-Device-Ip", "217.216.97.90")
+	req.Header.Add("X-Device-Referer", "https://vsco.co/")
+	req.Header.Add("X-Device-User-Agent", UserAgent)
+	req.Header.Add("X-Forwarded-For", "217.216.97.90, 172.71.144.58")
+	req.Header.Add("X-Requested-With", "com.instagram.android")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupRequest(req)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupRequest_Long_NoCache
+func Benchmark_LookupRequest_Long_NoCache(b *testing.B) {
+	wengine := fixtureCreateEngineCachesize(nil, "")
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 14; XQ-CT54 Build/64.2.A.2.258; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/146.0.7680.157 Mobile Safari/537.36 Instagram 422.0.0.44.64 Android (34/14; 420dpi; 1096x2560; Sony; XQ-CT54; XQ-CT54; qcom; en_GB; 916494010; IABMV/1)"
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("Accept", "*/*")
+	req.Header.Add("Accept-Encoding", "gzip, br")
+	req.Header.Add("Accept-Language", "en-GB,en-US;q=0.9,en;q=0.8")
+	req.Header.Add("Cdn-Loop", "cloudflare; loops=1")
+	req.Header.Add("Cf-Connecting-Ip", "217.216.97.90")
+	req.Header.Add("Cf-Ew-Via", "15")
+	req.Header.Add("Cf-Ipcountry", "DE")
+	req.Header.Add("Cf-Ray", "9e3709414e65a043-FRA")
+	req.Header.Add("Cf-Visitor", "{\"scheme\":\"https\"}")
+	req.Header.Add("Cf-Worker", "html-load.cc")
+	req.Header.Add("Forwarded", "for=217.216.97.90")
+	req.Header.Add("Host", "prebid.wurflcloud.com")
+	req.Header.Add("Referer", "https://vsco.co/")
+	req.Header.Add("Sec-Ch-Ua", "\"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Android WebView\";v=\"146\"")
+	req.Header.Add("Sec-Ch-Ua-Full-Version", "\"146.0.7680.157\"")
+	req.Header.Add("Sec-Ch-Ua-Full-Version-List", "\"Chromium\";v=\"146.0.7680.157\", \"Not-A.Brand\";v=\"24.0.0.0\", \"Android WebView\";v=\"146.0.7680.157\"")
+	req.Header.Add("Sec-Ch-Ua-Mobile", "?1")
+	req.Header.Add("Sec-Ch-Ua-Model", "\"XQ-CT54\"")
+	req.Header.Add("Sec-Ch-Ua-Platform", "\"Android\"")
+	req.Header.Add("Sec-Ch-Ua-Platform-Version", "\"14.0.0\"")
+	req.Header.Add("Sec-Fetch-Dest", "script")
+	req.Header.Add("Sec-Fetch-Mode", "no-cors")
+	req.Header.Add("Sec-Fetch-Site", "cross-site")
+	req.Header.Add("Sec-Fetch-Storage-Access", "active")
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("X-Amzn-Trace-Id", "Root=1-69c7d9dc-618fdb3e4d9456fc38f66cab")
+	req.Header.Add("X-As-Script-Type", "ESSENTIAL")
+	req.Header.Add("X-Device-Accept-Language", "en-GB,en-US;q=0.9,en;q=0.8")
+	req.Header.Add("X-Device-Ip", "217.216.97.90")
+	req.Header.Add("X-Device-Referer", "https://vsco.co/")
+	req.Header.Add("X-Device-User-Agent", UserAgent)
+	req.Header.Add("X-Forwarded-For", "217.216.97.90, 172.71.144.58")
+	req.Header.Add("X-Requested-With", "com.instagram.android")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupRequest(req)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupWithImportantHeaderMap_Long_Cache
+func Benchmark_LookupWithImportantHeaderMap_Long_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 14; XQ-CT54 Build/64.2.A.2.258; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/146.0.7680.157 Mobile Safari/537.36 Instagram 422.0.0.44.64 Android (34/14; 420dpi; 1096x2560; Sony; XQ-CT54; XQ-CT54; qcom; en_GB; 916494010; IABMV/1)"
+
+	IHMap := make(map[string]string)
+	IHMap["Accept"] = "*/*"
+	IHMap["Accept-Encoding"] = "gzip, br"
+	IHMap["Accept-Language"] = "en-GB,en-US;q=0.9,en;q=0.8"
+	IHMap["Cdn-Loop"] = "cloudflare; loops=1"
+	IHMap["Cf-Connecting-Ip"] = "217.216.97.90"
+	IHMap["Cf-Ew-Via"] = "15"
+	IHMap["Cf-Ipcountry"] = "DE"
+	IHMap["Cf-Ray"] = "9e3709414e65a043-FRA"
+	IHMap["Cf-Visitor"] = "{\"scheme\":\"https\"}"
+	IHMap["Cf-Worker"] = "html-load.cc"
+	IHMap["Forwarded"] = "for=217.216.97.90"
+	IHMap["Host"] = "prebid.wurflcloud.com"
+	IHMap["Referer"] = "https://vsco.co/"
+	IHMap["Sec-Ch-Ua"] = "\"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Android WebView\";v=\"146\""
+	IHMap["Sec-Ch-Ua-Full-Version"] = "\"146.0.7680.157\""
+	IHMap["Sec-Ch-Ua-Full-Version-List"] = "\"Chromium\";v=\"146.0.7680.157\", \"Not-A.Brand\";v=\"24.0.0.0\", \"Android WebView\";v=\"146.0.7680.157\""
+	IHMap["Sec-Ch-Ua-Mobile"] = "?1"
+	IHMap["Sec-Ch-Ua-Model"] = "\"XQ-CT54\""
+	IHMap["Sec-Ch-Ua-Platform"] = "\"Android\""
+	IHMap["Sec-Ch-Ua-Platform-Version"] = "\"14.0.0\""
+	IHMap["Sec-Fetch-Dest"] = "script"
+	IHMap["Sec-Fetch-Mode"] = "no-cors"
+	IHMap["Sec-Fetch-Site"] = "cross-site"
+	IHMap["Sec-Fetch-Storage-Access"] = "active"
+	IHMap["User-Agent"] = UserAgent
+	IHMap["X-Amzn-Trace-Id"] = "Root=1-69c7d9dc-618fdb3e4d9456fc38f66cab"
+	IHMap["X-As-Script-Type"] = "ESSENTIAL"
+	IHMap["X-Device-Accept-Language"] = "en-GB,en-US;q=0.9,en;q=0.8"
+	IHMap["X-Device-Ip"] = "217.216.97.90"
+	IHMap["X-Device-Referer"] = "https://vsco.co/"
+	IHMap["X-Device-User-Agent"] = UserAgent
+	IHMap["X-Forwarded-For"] = "217.216.97.90, 172.71.144.58"
+	IHMap["X-Requested-With"] = "com.instagram.android"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupWithImportantHeaderMap(IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupWithImportantHeaderMap_Long_NoCache
+func Benchmark_LookupWithImportantHeaderMap_Long_NoCache(b *testing.B) {
+	wengine := fixtureCreateEngineCachesize(nil, "")
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 14; XQ-CT54 Build/64.2.A.2.258; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/146.0.7680.157 Mobile Safari/537.36 Instagram 422.0.0.44.64 Android (34/14; 420dpi; 1096x2560; Sony; XQ-CT54; XQ-CT54; qcom; en_GB; 916494010; IABMV/1)"
+
+	IHMap := make(map[string]string)
+	IHMap["Accept"] = "*/*"
+	IHMap["Accept-Encoding"] = "gzip, br"
+	IHMap["Accept-Language"] = "en-GB,en-US;q=0.9,en;q=0.8"
+	IHMap["Cdn-Loop"] = "cloudflare; loops=1"
+	IHMap["Cf-Connecting-Ip"] = "217.216.97.90"
+	IHMap["Cf-Ew-Via"] = "15"
+	IHMap["Cf-Ipcountry"] = "DE"
+	IHMap["Cf-Ray"] = "9e3709414e65a043-FRA"
+	IHMap["Cf-Visitor"] = "{\"scheme\":\"https\"}"
+	IHMap["Cf-Worker"] = "html-load.cc"
+	IHMap["Forwarded"] = "for=217.216.97.90"
+	IHMap["Host"] = "prebid.wurflcloud.com"
+	IHMap["Referer"] = "https://vsco.co/"
+	IHMap["Sec-Ch-Ua"] = "\"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Android WebView\";v=\"146\""
+	IHMap["Sec-Ch-Ua-Full-Version"] = "\"146.0.7680.157\""
+	IHMap["Sec-Ch-Ua-Full-Version-List"] = "\"Chromium\";v=\"146.0.7680.157\", \"Not-A.Brand\";v=\"24.0.0.0\", \"Android WebView\";v=\"146.0.7680.157\""
+	IHMap["Sec-Ch-Ua-Mobile"] = "?1"
+	IHMap["Sec-Ch-Ua-Model"] = "\"XQ-CT54\""
+	IHMap["Sec-Ch-Ua-Platform"] = "\"Android\""
+	IHMap["Sec-Ch-Ua-Platform-Version"] = "\"14.0.0\""
+	IHMap["Sec-Fetch-Dest"] = "script"
+	IHMap["Sec-Fetch-Mode"] = "no-cors"
+	IHMap["Sec-Fetch-Site"] = "cross-site"
+	IHMap["Sec-Fetch-Storage-Access"] = "active"
+	IHMap["User-Agent"] = UserAgent
+	IHMap["X-Amzn-Trace-Id"] = "Root=1-69c7d9dc-618fdb3e4d9456fc38f66cab"
+	IHMap["X-As-Script-Type"] = "ESSENTIAL"
+	IHMap["X-Device-Accept-Language"] = "en-GB,en-US;q=0.9,en;q=0.8"
+	IHMap["X-Device-Ip"] = "217.216.97.90"
+	IHMap["X-Device-Referer"] = "https://vsco.co/"
+	IHMap["X-Device-User-Agent"] = UserAgent
+	IHMap["X-Forwarded-For"] = "217.216.97.90, 172.71.144.58"
+	IHMap["X-Requested-With"] = "com.instagram.android"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupWithImportantHeaderMap(IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupDeviceIDWithRequest_Cache
+func Benchmark_LookupDeviceIDWithRequest_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+	DeviceID := "samsung_sm_m315f_ver1_suban110"
+	// create http.Request and lookup using headers
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("Sec-CH-UA", "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\"")
+	req.Header.Add("Sec-CH-UA-Full-Version", "90.0.4430.91")
+	req.Header.Add("Sec-CH-UA-Platform", "Android")
+	req.Header.Add("Sec-CH-UA-Platform-Version", "11")
+	req.Header.Add("Sec-CH-UA-Model", "SM-M315F")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupDeviceIDWithRequest(DeviceID, req)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupDeviceIDWithRequest_NoCache
+func Benchmark_LookupDeviceIDWithRequest_NoCache(b *testing.B) {
+	wengine := fixtureCreateEngineCachesize(nil, "")
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+	DeviceID := "samsung_sm_m315f_ver1_suban110"
+	// create http.Request and lookup using headers
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("Sec-CH-UA", "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\"")
+	req.Header.Add("Sec-CH-UA-Full-Version", "90.0.4430.91")
+	req.Header.Add("Sec-CH-UA-Platform", "Android")
+	req.Header.Add("Sec-CH-UA-Platform-Version", "11")
+	req.Header.Add("Sec-CH-UA-Model", "SM-M315F")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupDeviceIDWithRequest(DeviceID, req)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupDeviceIDWithImportantHeaderMap_Cache
+func Benchmark_LookupDeviceIDWithImportantHeaderMap_Cache(b *testing.B) {
+	wengine := fixtureCreateEngine(nil)
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+	DeviceID := "samsung_sm_m315f_ver1_suban110"
+
+	IHMap := make(map[string]string)
+	IHMap["User-Agent"] = UserAgent
+	IHMap["Sec-CH-UA"] = "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\""
+	IHMap["Sec-CH-UA-Full-Version"] = "90.0.4430.91"
+	IHMap["Sec-CH-UA-Platform"] = "Android"
+	IHMap["Sec-CH-UA-Platform-Version"] = "11"
+	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupDeviceIDWithImportantHeaderMap(DeviceID, IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
+// Benchmark_LookupDeviceIDWithImportantHeaderMap_NoCache
+func Benchmark_LookupDeviceIDWithImportantHeaderMap_NoCache(b *testing.B) {
+	wengine := fixtureCreateEngineCachesize(nil, "")
+	defer wengine.Destroy()
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; SM-M315F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36"
+	DeviceID := "samsung_sm_m315f_ver1_suban110"
+
+	IHMap := make(map[string]string)
+	IHMap["User-Agent"] = UserAgent
+	IHMap["Sec-CH-UA"] = "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"90\", \"Google Chrome\";v=\"90\""
+	IHMap["Sec-CH-UA-Full-Version"] = "90.0.4430.91"
+	IHMap["Sec-CH-UA-Platform"] = "Android"
+	IHMap["Sec-CH-UA-Platform-Version"] = "11"
+	IHMap["Sec-CH-UA-Model"] = "SM-M315F"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+
+		device, _ := wengine.LookupDeviceIDWithImportantHeaderMap(DeviceID, IHMap)
+		device.Destroy()
+	}
+
+	b.StopTimer()
+}
+
 // GetAllCaps benchmarks
 func Benchmark_GetAllCaps(b *testing.B) {
 	wengine := fixtureCreateEngine(nil)

--- a/bench_test.go
+++ b/bench_test.go
@@ -1204,3 +1204,16 @@ func Benchmark_StringToLower(b *testing.B) {
 	}
 	b.StopTimer()
 }
+
+var sinkBool bool
+
+func Benchmark_StringEqualFold(b *testing.B) {
+	headerName := "Sec-CH-UA-Platform-Version"
+	headerNameLower := "sec-ch-ua-platform-version"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkBool = strings.EqualFold(headerName, headerNameLower)
+	}
+	b.StopTimer()
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -3,6 +3,7 @@ package wurfl_test
 import (
 	"net/http"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -1098,4 +1099,17 @@ func TestP99_LookupUserAgent_NoCache(t *testing.T) {
 	t.Logf("P95:  %v", p95)
 	t.Logf("P99:  %v", p99)
 	t.Logf("P100: %v", p100)
+}
+
+// used to prevent compiler optimizations in the BenchmarkStringToLower
+var sinkString string
+
+func BenchmarkStringToLower(b *testing.B) {
+	headerName := "Sec-CH-UA-Platform-Version"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkString = strings.ToLower(headerName)
+	}
+	b.StopTimer()
 }

--- a/wurfl.go
+++ b/wurfl.go
@@ -258,7 +258,7 @@ type Updater interface {
 }
 
 // Version is the current version of this package.
-const Version = "1.32.1"
+const Version = "1.33.0"
 
 // APIVersion returns version of internal InFuze API without an initialized engine
 func APIVersion() string {

--- a/wurfl.go
+++ b/wurfl.go
@@ -794,18 +794,16 @@ func (w *Wurfl) LookupDeviceIDWithImportantHeaderMap(DeviceID string, IHMap map[
 
 	// fill it with IHMap entries
 
-	for i, importantHeaderName := range w.ImportantHeaderNames {
-		// retrieve header from IHMap
-		header := IHMap[importantHeaderName]
-		if len(header) != 0 {
+	// fill it with IHMap entries
+	for importantHeaderName, headerValue := range IHMap {
+		// create C strings from header name and value
+		cheaderName := C.CString(importantHeaderName)
+		cheaderValue := C.CString(headerValue)
 
-			// create a C string from header
-			cheader := C.CString(header)
-
-			// add this header to cih
-			C.wurfl_important_header_set(cih, w.importantHeaderCStringNames[i], cheader)
-			C.free(unsafe.Pointer(cheader))
-		}
+		// add this header to WURFL importtant headers object
+		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
+		C.free(unsafe.Pointer(cheaderName))
+		C.free(unsafe.Pointer(cheaderValue))
 	}
 
 	d.Device = C.wurfl_get_device_with_important_header(w.Wurfl, cDeviceID, cih)

--- a/wurfl.go
+++ b/wurfl.go
@@ -817,16 +817,15 @@ func (w *Wurfl) LookupWithImportantHeaderMap(IHMap map[string]string) (*Device, 
 		return nil, checkHandleError(w.Wurfl)
 	}
 	defer C.wurfl_important_header_destroy(cih)
-	// fill it with IHMap entries, using trie for case-insensitive lookup and reusable buffer to avoid malloc/free
-	buf := make([]byte, 0, 256)
+	// fill it with IHMap entries, using trie for case-insensitive header name lookup
 	for importantHeaderName, headerValue := range IHMap {
 		cheaderName, found := w.importantHeaderTrie.get(importantHeaderName)
 		if !found {
 			continue
 		}
-		buf = append(buf[:0], headerValue...)
-		buf = append(buf, 0)
-		C.wurfl_important_header_set(cih, cheaderName, (*C.char)(unsafe.Pointer(&buf[0])))
+		cheaderValue := C.CString(headerValue)
+		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
+		C.free(unsafe.Pointer(cheaderValue))
 	}
 
 	d.Device = C.wurfl_lookup_with_important_header(w.Wurfl, cih)
@@ -856,16 +855,15 @@ func (w *Wurfl) LookupDeviceIDWithImportantHeaderMap(DeviceID string, IHMap map[
 	}
 	defer C.wurfl_important_header_destroy(cih)
 
-	// fill it with IHMap entries, using trie for case-insensitive lookup and reusable buffer to avoid malloc/free
-	buf := make([]byte, 0, 256)
+	// fill it with IHMap entries, using trie for case-insensitive header name lookup
 	for importantHeaderName, headerValue := range IHMap {
 		cheaderName, found := w.importantHeaderTrie.get(importantHeaderName)
 		if !found {
 			continue
 		}
-		buf = append(buf[:0], headerValue...)
-		buf = append(buf, 0)
-		C.wurfl_important_header_set(cih, cheaderName, (*C.char)(unsafe.Pointer(&buf[0])))
+		cheaderValue := C.CString(headerValue)
+		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
+		C.free(unsafe.Pointer(cheaderValue))
 	}
 
 	d.Device = C.wurfl_get_device_with_important_header(w.Wurfl, cDeviceID, cih)

--- a/wurfl.go
+++ b/wurfl.go
@@ -846,6 +846,7 @@ func (w *Wurfl) LookupDeviceIDWithImportantHeaderMap(DeviceID string, IHMap map[
 	d.capsCStringcache = w.capsCStringcache
 
 	cDeviceID := C.CString(DeviceID)
+	defer C.free(unsafe.Pointer(cDeviceID))
 
 	// create important headers object to pass to lookup
 
@@ -867,7 +868,6 @@ func (w *Wurfl) LookupDeviceIDWithImportantHeaderMap(DeviceID string, IHMap map[
 	}
 
 	d.Device = C.wurfl_get_device_with_important_header(w.Wurfl, cDeviceID, cih)
-	C.free(unsafe.Pointer(cDeviceID))
 	if d.Device == nil {
 		return nil, checkHandleError(w.Wurfl)
 	}

--- a/wurfl.go
+++ b/wurfl.go
@@ -1382,8 +1382,8 @@ func BenchmarkableSequentialEqualFoldGet(headerNames []string) func(string) unsa
 }
 
 // BenchmarkableBinarySearchFoldGet creates a sorted slice of pre-lowercased header names
-// paired with their pre-allocated *C.char pointers. Lookup uses sort.Search with a | 0x20
-// byte-folding comparator, then confirms with strings.EqualFold and returns the *C.char.
+// paired with their pre-allocated *C.char pointers. Lookup uses a custom inline binary search
+// with | 0x20 byte-folding comparison, avoiding sort.Search closure overhead.
 // Zero allocations.
 func BenchmarkableBinarySearchFoldGet(headerNames []string) func(string) unsafe.Pointer {
 	type entry struct {
@@ -1398,33 +1398,66 @@ func BenchmarkableBinarySearchFoldGet(headerNames []string) func(string) unsafe.
 		return entries[i].lower < entries[j].lower
 	})
 	return func(key string) unsafe.Pointer {
-		i := sort.Search(len(entries), func(mid int) bool {
-			return asciiCmpFoldGe(entries[mid].lower, key)
-		})
-		if i >= len(entries) {
-			return nil
+		lo, hi := 0, len(entries)
+		for lo < hi {
+			mid := lo + (hi-lo)/2
+			// compare entries[mid].lower (pre-lowered) against key (arbitrary case)
+			// fold key bytes with | 0x20 inline
+			cmp := asciiCmpFold(entries[mid].lower, key)
+			if cmp == 0 {
+				return unsafe.Pointer(entries[mid].cname)
+			}
+			if cmp < 0 {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
 		}
-		if !strings.EqualFold(entries[i].lower, key) {
-			return nil
-		}
-		return unsafe.Pointer(entries[i].cname)
+		return nil
 	}
 }
 
-// asciiCmpFoldGe returns true if a >= b in case-insensitive ASCII order.
-// a is expected to be pre-lowered; b is folded inline with | 0x20.
-func asciiCmpFoldGe(a, b string) bool {
-	minLen := len(a)
-	if len(b) < minLen {
-		minLen = len(b)
+// asciiCmpFold performs a case-insensitive comparison of two ASCII strings for use
+// in binary search over a sorted slice of pre-lowercased header names.
+//
+// entryLower must be pre-lowercased (as stored in the sorted slice).
+// key can be in any case — only uppercase ASCII letters (A-Z) are folded to lowercase
+// via | 0x20, which is safe because it only affects bytes in the 0x41-0x5A range.
+// Non-letter characters (digits, hyphens, etc.) are compared as-is.
+//
+// Returns -1 if entryLower < key, 0 if equal, +1 if entryLower > key.
+func asciiCmpFold(entryLower string, key string) int {
+	// compare up to the length of the shorter string
+	n := len(entryLower)
+	if len(key) < n {
+		n = len(key)
 	}
-	for i := 0; i < minLen; i++ {
-		cb := b[i] | 0x20
-		if a[i] != cb {
-			return a[i] >= cb
+
+	for i := 0; i < n; i++ {
+		a := entryLower[i] // already lowercase
+		b := key[i]
+
+		// fold only uppercase ASCII letters to lowercase
+		if b >= 'A' && b <= 'Z' {
+			b |= 0x20
+		}
+
+		// if bytes differ after folding, we have our ordering
+		if a != b {
+			if a < b {
+				return -1
+			}
+			return 1
 		}
 	}
-	return len(a) >= len(b)
+
+	// all compared bytes are equal — the shorter string is "less than"
+	if len(entryLower) < len(key) {
+		return -1
+	} else if len(entryLower) > len(key) {
+		return 1
+	}
+	return 0
 }
 
 // CompareVersions Returns 0 if v1 == v2, -1 if v1 < v2, and 1 if v1 > v2.

--- a/wurfl.go
+++ b/wurfl.go
@@ -128,12 +128,43 @@ const (
 	HeaderQualityFull HeaderQuality = C.WURFL_ENUM_UACH_FULL
 )
 
+// headerTrie is a case-insensitive trie for ASCII header name lookup.
+// It avoids strings.ToLower allocations by folding case per-byte during traversal.
+type headerTrie struct {
+	children [128]*headerTrie
+	value    *C.char // non-nil at terminal nodes
+}
+
+func (t *headerTrie) set(key string, val *C.char) {
+	node := t
+	for i := 0; i < len(key); i++ {
+		c := key[i] | 0x20 // ASCII lowercase
+		if node.children[c] == nil {
+			node.children[c] = &headerTrie{}
+		}
+		node = node.children[c]
+	}
+	node.value = val
+}
+
+func (t *headerTrie) get(key string) (*C.char, bool) {
+	node := t
+	for i := 0; i < len(key); i++ {
+		c := key[i] | 0x20
+		node = node.children[c]
+		if node == nil {
+			return nil, false
+		}
+	}
+	return node.value, node.value != nil
+}
+
 // Wurfl represents internal wurfl infuze handle
 type Wurfl struct {
 	Wurfl                       C.wurfl_handle
 	ImportantHeaderNames        []string
 	importantHeaderCStringNames []*C.char
-	importantHeaderCStringMap   map[string]*C.char
+	importantHeaderTrie         headerTrie
 	capsCStringcache            map[string]*C.char
 }
 
@@ -320,10 +351,10 @@ func Create(Wurflxml string, Patches []string, CapFilter []string, EngineTarget 
 		C.wurfl_important_header_enumerator_move_next(ihe)
 	}
 
-	// build a map-based cache for important header names, keyed by lowercase for case-insensitive lookup
-	w.importantHeaderCStringMap = make(map[string]*C.char, len(w.ImportantHeaderNames))
+	// build a trie-based cache for important header names, for case-insensitive lookup without allocation
+	w.importantHeaderTrie = headerTrie{}
 	for i, name := range w.ImportantHeaderNames {
-		w.importantHeaderCStringMap[strings.ToLower(name)] = w.importantHeaderCStringNames[i]
+		w.importantHeaderTrie.set(name, w.importantHeaderCStringNames[i])
 	}
 
 	// initialize caps/vcaps CString cache for faster calls to libwurfl
@@ -403,10 +434,10 @@ func (w *Wurfl) SetAttr(attr int, value int) error {
 		}
 		C.wurfl_important_header_enumerator_destroy(ihe)
 
-		// rebuild the map-based cache for important header names
-		w.importantHeaderCStringMap = make(map[string]*C.char, len(w.ImportantHeaderNames))
+		// rebuild the trie-based cache for important header names
+		w.importantHeaderTrie = headerTrie{}
 		for i, name := range w.ImportantHeaderNames {
-			w.importantHeaderCStringMap[strings.ToLower(name)] = w.importantHeaderCStringNames[i]
+			w.importantHeaderTrie.set(name, w.importantHeaderCStringNames[i])
 		}
 	}
 
@@ -766,18 +797,16 @@ func (w *Wurfl) LookupWithImportantHeaderMap(IHMap map[string]string) (*Device, 
 		return nil, checkHandleError(w.Wurfl)
 	}
 	defer C.wurfl_important_header_destroy(cih)
-	// fill it with IHMap entries
+	// fill it with IHMap entries, using trie for case-insensitive lookup and reusable buffer to avoid malloc/free
+	buf := make([]byte, 0, 256)
 	for importantHeaderName, headerValue := range IHMap {
-		// use cached C string for header name (case-insensitive lookup)
-		cheaderName, found := w.importantHeaderCStringMap[strings.ToLower(importantHeaderName)]
+		cheaderName, found := w.importantHeaderTrie.get(importantHeaderName)
 		if !found {
 			continue
 		}
-		cheaderValue := C.CString(headerValue)
-
-		// add this header to WURFL important headers object
-		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
-		C.free(unsafe.Pointer(cheaderValue))
+		buf = append(buf[:0], headerValue...)
+		buf = append(buf, 0)
+		C.wurfl_important_header_set(cih, cheaderName, (*C.char)(unsafe.Pointer(&buf[0])))
 	}
 
 	d.Device = C.wurfl_lookup_with_important_header(w.Wurfl, cih)
@@ -807,18 +836,16 @@ func (w *Wurfl) LookupDeviceIDWithImportantHeaderMap(DeviceID string, IHMap map[
 	}
 	defer C.wurfl_important_header_destroy(cih)
 
-	// fill it with IHMap entries
+	// fill it with IHMap entries, using trie for case-insensitive lookup and reusable buffer to avoid malloc/free
+	buf := make([]byte, 0, 256)
 	for importantHeaderName, headerValue := range IHMap {
-		// use cached C string for header name (case-insensitive lookup)
-		cheaderName, found := w.importantHeaderCStringMap[strings.ToLower(importantHeaderName)]
+		cheaderName, found := w.importantHeaderTrie.get(importantHeaderName)
 		if !found {
 			continue
 		}
-		cheaderValue := C.CString(headerValue)
-
-		// add this header to WURFL important headers object
-		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
-		C.free(unsafe.Pointer(cheaderValue))
+		buf = append(buf[:0], headerValue...)
+		buf = append(buf, 0)
+		C.wurfl_important_header_set(cih, cheaderName, (*C.char)(unsafe.Pointer(&buf[0])))
 	}
 
 	d.Device = C.wurfl_get_device_with_important_header(w.Wurfl, cDeviceID, cih)

--- a/wurfl.go
+++ b/wurfl.go
@@ -312,8 +312,8 @@ func Create(Wurflxml string, Patches []string, CapFilter []string, EngineTarget 
 
 	// setting wurfl.xml
 	wxml := C.CString(Wurflxml)
+	defer C.free(unsafe.Pointer(wxml))
 	if ret := C.wurfl_set_root(w.Wurfl, wxml); ret != C.WURFL_OK {
-		C.free(unsafe.Pointer(wxml))
 		w.Destroy()
 		return nil, cErrorToGoError(ret)
 	}
@@ -770,6 +770,7 @@ func (w *Wurfl) LookupDeviceIDWithRequest(DeviceID string, r *http.Request) (*De
 	d.capsCStringcache = w.capsCStringcache
 
 	wDeviceID := C.CString(DeviceID)
+	defer C.free(unsafe.Pointer(wDeviceID))
 
 	// create important headers object to pass to lookup
 
@@ -794,7 +795,6 @@ func (w *Wurfl) LookupDeviceIDWithRequest(DeviceID string, r *http.Request) (*De
 	}
 
 	d.Device = C.wurfl_get_device_with_important_header(w.Wurfl, wDeviceID, cih)
-	C.free(unsafe.Pointer(wDeviceID))
 	if d.Device == nil {
 		return nil, checkHandleError(w.Wurfl)
 	}
@@ -1355,8 +1355,6 @@ func BenchmarkableMapGet(headerNames []string) func(string) unsafe.Pointer {
 		return unsafe.Pointer(cname)
 	}
 }
-
-
 
 // CompareVersions Returns 0 if v1 == v2, -1 if v1 < v2, and 1 if v1 > v2.
 func CompareVersions(v1, v2 string) int {

--- a/wurfl.go
+++ b/wurfl.go
@@ -133,6 +133,7 @@ type Wurfl struct {
 	Wurfl                       C.wurfl_handle
 	ImportantHeaderNames        []string
 	importantHeaderCStringNames []*C.char
+	importantHeaderCStringMap   map[string]*C.char
 	capsCStringcache            map[string]*C.char
 }
 
@@ -319,6 +320,12 @@ func Create(Wurflxml string, Patches []string, CapFilter []string, EngineTarget 
 		C.wurfl_important_header_enumerator_move_next(ihe)
 	}
 
+	// build a map-based cache for important header names, keyed by lowercase for case-insensitive lookup
+	w.importantHeaderCStringMap = make(map[string]*C.char, len(w.ImportantHeaderNames))
+	for i, name := range w.ImportantHeaderNames {
+		w.importantHeaderCStringMap[strings.ToLower(name)] = w.importantHeaderCStringNames[i]
+	}
+
 	// initialize caps/vcaps CString cache for faster calls to libwurfl
 
 	caps := w.GetAllCaps()
@@ -395,6 +402,12 @@ func (w *Wurfl) SetAttr(attr int, value int) error {
 			C.wurfl_important_header_enumerator_move_next(ihe)
 		}
 		C.wurfl_important_header_enumerator_destroy(ihe)
+
+		// rebuild the map-based cache for important header names
+		w.importantHeaderCStringMap = make(map[string]*C.char, len(w.ImportantHeaderNames))
+		for i, name := range w.ImportantHeaderNames {
+			w.importantHeaderCStringMap[strings.ToLower(name)] = w.importantHeaderCStringNames[i]
+		}
 	}
 
 	return nil
@@ -755,13 +768,15 @@ func (w *Wurfl) LookupWithImportantHeaderMap(IHMap map[string]string) (*Device, 
 	defer C.wurfl_important_header_destroy(cih)
 	// fill it with IHMap entries
 	for importantHeaderName, headerValue := range IHMap {
-		// create C strings from header name and value
-		cheaderName := C.CString(importantHeaderName)
+		// use cached C string for header name (case-insensitive lookup)
+		cheaderName, found := w.importantHeaderCStringMap[strings.ToLower(importantHeaderName)]
+		if !found {
+			continue
+		}
 		cheaderValue := C.CString(headerValue)
 
-		// add this header to WURFL importtant headers object
+		// add this header to WURFL important headers object
 		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
-		C.free(unsafe.Pointer(cheaderName))
 		C.free(unsafe.Pointer(cheaderValue))
 	}
 
@@ -793,16 +808,16 @@ func (w *Wurfl) LookupDeviceIDWithImportantHeaderMap(DeviceID string, IHMap map[
 	defer C.wurfl_important_header_destroy(cih)
 
 	// fill it with IHMap entries
-
-	// fill it with IHMap entries
 	for importantHeaderName, headerValue := range IHMap {
-		// create C strings from header name and value
-		cheaderName := C.CString(importantHeaderName)
+		// use cached C string for header name (case-insensitive lookup)
+		cheaderName, found := w.importantHeaderCStringMap[strings.ToLower(importantHeaderName)]
+		if !found {
+			continue
+		}
 		cheaderValue := C.CString(headerValue)
 
-		// add this header to WURFL importtant headers object
+		// add this header to WURFL important headers object
 		C.wurfl_important_header_set(cih, cheaderName, cheaderValue)
-		C.free(unsafe.Pointer(cheaderName))
 		C.free(unsafe.Pointer(cheaderValue))
 	}
 

--- a/wurfl.go
+++ b/wurfl.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -1317,6 +1318,113 @@ func GoStringToCStringAndFree(capname string) *C.char {
 // GoStringToCStringUsingMap returns a C string pointer for the given capability name using a cached map.
 func (w *Wurfl) GoStringToCStringUsingMap(capname string) *C.char {
 	return w.capsCStringcache[capname]
+}
+
+// BenchmarkableTrieGet creates an isolated headerTrie populated with the given header names
+// and returns a function that performs a case-insensitive get() on the trie.
+// Returns unsafe.Pointer to the *C.char on match (nil if not found), reflecting the real
+// use case where the lookup must return a ready-to-use C string pointer.
+func BenchmarkableTrieGet(headerNames []string) func(string) unsafe.Pointer {
+	var trie headerTrie
+	for _, name := range headerNames {
+		cname := C.CString(name)
+		trie.set(name, cname)
+	}
+	return func(key string) unsafe.Pointer {
+		cname, found := trie.get(key)
+		if !found {
+			return nil
+		}
+		return unsafe.Pointer(cname)
+	}
+}
+
+// BenchmarkableMapGet creates a map[string]*C.char keyed by pre-lowercased header names,
+// mirroring importantHeaderCStringMap from the ihm-lookup-opt branch.
+// Lookup does strings.ToLower(key) + map access. The ToLower allocation is unavoidable
+// because map lookup requires an exact key match for hashing.
+// Returns unsafe.Pointer to the *C.char on match (nil if not found).
+func BenchmarkableMapGet(headerNames []string) func(string) unsafe.Pointer {
+	m := make(map[string]*C.char, len(headerNames))
+	for _, name := range headerNames {
+		cname := C.CString(name)
+		m[strings.ToLower(name)] = cname
+	}
+	return func(key string) unsafe.Pointer {
+		cname, found := m[strings.ToLower(key)]
+		if !found {
+			return nil
+		}
+		return unsafe.Pointer(cname)
+	}
+}
+
+// BenchmarkableSequentialEqualFoldGet creates a slice of header names paired with their
+// pre-allocated *C.char pointers. Lookup iterates sequentially using strings.EqualFold
+// and returns the corresponding *C.char. Zero allocations.
+func BenchmarkableSequentialEqualFoldGet(headerNames []string) func(string) unsafe.Pointer {
+	type entry struct {
+		name  string
+		cname *C.char
+	}
+	entries := make([]entry, len(headerNames))
+	for i, name := range headerNames {
+		entries[i] = entry{name, C.CString(name)}
+	}
+	return func(key string) unsafe.Pointer {
+		for _, e := range entries {
+			if strings.EqualFold(e.name, key) {
+				return unsafe.Pointer(e.cname)
+			}
+		}
+		return nil
+	}
+}
+
+// BenchmarkableBinarySearchFoldGet creates a sorted slice of pre-lowercased header names
+// paired with their pre-allocated *C.char pointers. Lookup uses sort.Search with a | 0x20
+// byte-folding comparator, then confirms with strings.EqualFold and returns the *C.char.
+// Zero allocations.
+func BenchmarkableBinarySearchFoldGet(headerNames []string) func(string) unsafe.Pointer {
+	type entry struct {
+		lower string
+		cname *C.char
+	}
+	entries := make([]entry, len(headerNames))
+	for i, name := range headerNames {
+		entries[i] = entry{strings.ToLower(name), C.CString(name)}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].lower < entries[j].lower
+	})
+	return func(key string) unsafe.Pointer {
+		i := sort.Search(len(entries), func(mid int) bool {
+			return asciiCmpFoldGe(entries[mid].lower, key)
+		})
+		if i >= len(entries) {
+			return nil
+		}
+		if !strings.EqualFold(entries[i].lower, key) {
+			return nil
+		}
+		return unsafe.Pointer(entries[i].cname)
+	}
+}
+
+// asciiCmpFoldGe returns true if a >= b in case-insensitive ASCII order.
+// a is expected to be pre-lowered; b is folded inline with | 0x20.
+func asciiCmpFoldGe(a, b string) bool {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		cb := b[i] | 0x20
+		if a[i] != cb {
+			return a[i] >= cb
+		}
+	}
+	return len(a) >= len(b)
 }
 
 // CompareVersions Returns 0 if v1 == v2, -1 if v1 < v2, and 1 if v1 > v2.

--- a/wurfl.go
+++ b/wurfl.go
@@ -128,17 +128,35 @@ const (
 	HeaderQualityFull HeaderQuality = C.WURFL_ENUM_UACH_FULL
 )
 
-// headerTrie is a case-insensitive trie for ASCII header name lookup.
-// It avoids strings.ToLower allocations by folding case per-byte during traversal.
+// headerTrie is a case-insensitive trie (prefix tree) for mapping HTTP header names
+// to their pre-allocated C string counterparts.
+//
+// Why a trie: LookupWithImportantHeaderMap receives a map[string]string where keys are
+// header names in arbitrary case (e.g. "User-Agent", "user-agent", "USER-AGENT").
+// We need to match them against WURFL's known important header names case-insensitively.
+// The trie avoids this by folding case inline during traversal using a bit trick,
+// achieving O(len(key)) lookup with zero allocations.
+//
+// How case folding works: each byte is OR-ed with 0x20 (bit 5), which converts ASCII
+// uppercase letters to lowercase (e.g. 'A' 0x41 -> 'a' 0x61) without affecting lowercase
+// letters, digits, or hyphens — the only characters that appear in HTTP header names.
+// Both set() and get() apply the same folding, so "Sec-CH-UA" and "sec-ch-ua" follow
+// the same path in the trie.
+//
+// The stored value at each terminal node is a *C.char pointer to a C string allocated once
+// at engine initialization. This means get() returns a ready-to-use C string directly,
+// avoiding a C.CString() call (and its cgo malloc overhead) on every lookup.
 type headerTrie struct {
 	children [128]*headerTrie
-	value    *C.char // non-nil at terminal nodes
+	value    *C.char // non-nil at terminal nodes, points to pre-allocated C string
 }
 
+// set inserts a header name into the trie, associating it with a pre-allocated C string.
+// Called once per important header at engine initialization.
 func (t *headerTrie) set(key string, val *C.char) {
 	node := t
 	for i := 0; i < len(key); i++ {
-		c := key[i] | 0x20 // ASCII lowercase
+		c := key[i] | 0x20 // fold to lowercase: safe for [A-Za-z0-9\-]
 		if node.children[c] == nil {
 			node.children[c] = &headerTrie{}
 		}
@@ -147,10 +165,12 @@ func (t *headerTrie) set(key string, val *C.char) {
 	node.value = val
 }
 
+// get performs a case-insensitive lookup and returns the pre-allocated *C.char for the
+// header name, or (nil, false) if the key is not a known important header.
 func (t *headerTrie) get(key string) (*C.char, bool) {
 	node := t
 	for i := 0; i < len(key); i++ {
-		c := key[i] | 0x20
+		c := key[i] | 0x20 // same case folding as set()
 		node = node.children[c]
 		if node == nil {
 			return nil, false

--- a/wurfl.go
+++ b/wurfl.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -1359,106 +1358,7 @@ func BenchmarkableMapGet(headerNames []string) func(string) unsafe.Pointer {
 	}
 }
 
-// BenchmarkableSequentialEqualFoldGet creates a slice of header names paired with their
-// pre-allocated *C.char pointers. Lookup iterates sequentially using strings.EqualFold
-// and returns the corresponding *C.char. Zero allocations.
-func BenchmarkableSequentialEqualFoldGet(headerNames []string) func(string) unsafe.Pointer {
-	type entry struct {
-		name  string
-		cname *C.char
-	}
-	entries := make([]entry, len(headerNames))
-	for i, name := range headerNames {
-		entries[i] = entry{name, C.CString(name)}
-	}
-	return func(key string) unsafe.Pointer {
-		for _, e := range entries {
-			if strings.EqualFold(e.name, key) {
-				return unsafe.Pointer(e.cname)
-			}
-		}
-		return nil
-	}
-}
 
-// BenchmarkableBinarySearchFoldGet creates a sorted slice of pre-lowercased header names
-// paired with their pre-allocated *C.char pointers. Lookup uses a custom inline binary search
-// with | 0x20 byte-folding comparison, avoiding sort.Search closure overhead.
-// Zero allocations.
-func BenchmarkableBinarySearchFoldGet(headerNames []string) func(string) unsafe.Pointer {
-	type entry struct {
-		lower string
-		cname *C.char
-	}
-	entries := make([]entry, len(headerNames))
-	for i, name := range headerNames {
-		entries[i] = entry{strings.ToLower(name), C.CString(name)}
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].lower < entries[j].lower
-	})
-	return func(key string) unsafe.Pointer {
-		lo, hi := 0, len(entries)
-		for lo < hi {
-			mid := lo + (hi-lo)/2
-			// compare entries[mid].lower (pre-lowered) against key (arbitrary case)
-			// fold key bytes with | 0x20 inline
-			cmp := asciiCmpFold(entries[mid].lower, key)
-			if cmp == 0 {
-				return unsafe.Pointer(entries[mid].cname)
-			}
-			if cmp < 0 {
-				lo = mid + 1
-			} else {
-				hi = mid
-			}
-		}
-		return nil
-	}
-}
-
-// asciiCmpFold performs a case-insensitive comparison of two ASCII strings for use
-// in binary search over a sorted slice of pre-lowercased header names.
-//
-// entryLower must be pre-lowercased (as stored in the sorted slice).
-// key can be in any case — only uppercase ASCII letters (A-Z) are folded to lowercase
-// via | 0x20, which is safe because it only affects bytes in the 0x41-0x5A range.
-// Non-letter characters (digits, hyphens, etc.) are compared as-is.
-//
-// Returns -1 if entryLower < key, 0 if equal, +1 if entryLower > key.
-func asciiCmpFold(entryLower string, key string) int {
-	// compare up to the length of the shorter string
-	n := len(entryLower)
-	if len(key) < n {
-		n = len(key)
-	}
-
-	for i := 0; i < n; i++ {
-		a := entryLower[i] // already lowercase
-		b := key[i]
-
-		// fold only uppercase ASCII letters to lowercase
-		if b >= 'A' && b <= 'Z' {
-			b |= 0x20
-		}
-
-		// if bytes differ after folding, we have our ordering
-		if a != b {
-			if a < b {
-				return -1
-			}
-			return 1
-		}
-	}
-
-	// all compared bytes are equal — the shorter string is "less than"
-	if len(entryLower) < len(key) {
-		return -1
-	} else if len(entryLower) > len(key) {
-		return 1
-	}
-	return 0
-}
 
 // CompareVersions Returns 0 if v1 == v2, -1 if v1 < v2, and 1 if v1 > v2.
 func CompareVersions(v1, v2 string) int {

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -273,6 +273,32 @@ func Test_GetCapability(t *testing.T) {
 	device.Destroy()
 }
 
+func Test_LookupRequestCaseInsensitiveHeaders(t *testing.T) {
+
+	wengine := fixtureCreateEngine(t)
+	require.NotNil(t, wengine)
+	defer wengine.Destroy()
+
+	// User-Agent
+	UserAgent := "Mozilla/5.0 (Linux; Android 11; Mi 9 Lite Build/QKQ1.190828.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/135.0.7049.113 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/511.0.0.73.36;IABMV/1;]"
+
+	// create http.Request and lookup using headers
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("User-AgeNT", UserAgent)
+	req.Header.Add("Accept", "*/*")
+	req.Header.Add("SEc-Ch-UA", `"Android WebView";v="135", "Not-A.Brand";v="8", "Chromium";v="135"`)
+	req.Header.Add("Sec-Ch-Ua-MObiLe", "?1")
+	req.Header.Add("Sec-Ch-Ua-PlatFORM", "Android")
+	req.Header.Add("Sec-Ch-Ua-PlatFORM-VERsIOn", "12")
+
+	reqDevice, err := wengine.LookupRequest(req)
+	assert.NoErrorf(t, err, "LookupRequest returned an error: %s", err)
+	reqDeviceID, _ := reqDevice.GetDeviceID()
+	assert.Equal(t, "xiaomi_mi_9_lite_ver1_suban110", reqDeviceID)
+
+	reqDevice.Destroy()
+}
+
 func Test_LookupRequest(t *testing.T) {
 
 	wengine := fixtureCreateEngine(t)

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -502,6 +502,49 @@ func Test_LookupWithImportantHeaderMapCaseInsensitive(t *testing.T) {
 	deviceIHM.Destroy()
 }
 
+func Test_LookupDeviceIDWithImportantHeaderMapCaseInsensitive(t *testing.T) {
+	wengine := fixtureCreateEngine(t)
+	require.NotNil(t, wengine)
+	defer wengine.Destroy()
+
+	UserAgent := "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36"
+
+	deviceLA, err := wengine.LookupUserAgent(UserAgent)
+	assert.NoErrorf(t, err, "LookupUserAgent returned an error: %s", err)
+
+	LaDeviceID, _ := deviceLA.GetDeviceID()
+	LAAdvertisedBrowser, _ := deviceLA.GetVirtualCap("advertised_browser")
+
+	// create IHMap and lookup using headers. Headers names will have some case differences
+	// to check that LookuupWithImportantHeaderMap() is case insensitive
+
+	// Where strings could contain double quotes (") delimit values using backticks (`) to avoid escaping
+	IHMap := make(map[string]string)
+	IHMap["User-Agent"] = UserAgent
+	IHMap["accept-encoding"] = "gzip, deflate, br, zstd"
+	IHMap["Sec-ch-UA-Platform"] = "Android"
+	IHMap["Sec-CH-ua"] = `"Chromium";v="122", "Not(A:Brand";v="24", "Veera";v="122"`
+	IHMap["SEC-CH-UA-MOBILE"] = "?1"
+	IHMap["seC-cH-uA-fulL-versioN-lisT"] = `"Chromium";v="122.0.0.0", "Not(A:Brand";v="24.0.0.0", "Veera";v="122.0.0.0"`
+
+	deviceIHM, err := wengine.LookupDeviceIDWithImportantHeaderMap(LaDeviceID, IHMap)
+	assert.NoErrorf(t, err, "LookupDeviceIDWithImportantHeaderMap returned an error: %s", err)
+
+	IHMDeviceID, _ := deviceIHM.GetDeviceID()
+	IHMAdvertisedBrowser, _ := deviceIHM.GetVirtualCap("advertised_browser")
+	if LaDeviceID != IHMDeviceID {
+		t.Errorf("Devices are different, should be the same : %s, %s\n", LaDeviceID, IHMDeviceID)
+	}
+
+	// If case insensitivity is not working, the lookup with important header map will not find the same advertised_browser vcap will be different (Chrome instead of Veera)
+	if LAAdvertisedBrowser == IHMAdvertisedBrowser {
+		t.Errorf("advertised_browser are the same, should be different : %s, %s\n", LAAdvertisedBrowser, IHMAdvertisedBrowser)
+	}
+
+	deviceLA.Destroy()
+	deviceIHM.Destroy()
+}
+
 func Test_LookupDeviceIDWithRequest(t *testing.T) {
 
 	wengine := fixtureCreateEngine(t)

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -571,6 +571,92 @@ func Test_LookupDeviceIDWithImportantHeaderMapCaseInsensitive(t *testing.T) {
 	deviceIHM.Destroy()
 }
 
+// Test_LookupWithImportantHeaderMap_CaseConsistency verifies that the trie-based
+// case-insensitive header name lookup produces identical detection results regardless
+// of the casing used for header names. The same header values are submitted with
+// multiple case variations, and all lookups must return the same device ID and capabilities.
+func Test_LookupWithImportantHeaderMap_CaseConsistency(t *testing.T) {
+	wengine := fixtureCreateEngine(t)
+	require.NotNil(t, wengine)
+	defer wengine.Destroy()
+
+	// header values shared across all case variants
+	headerValues := map[string]string{
+		"User-Agent":                 "Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36",
+		"Sec-CH-UA":                  `"Chromium";v="122", "Not(A:Brand";v="24", "Google Chrome";v="122"`,
+		"Sec-CH-UA-Full-Version-List": `"Chromium";v="122.0.6261.64", "Not(A:Brand";v="24.0.0.0", "Google Chrome";v="122.0.6261.64"`,
+		"Sec-CH-UA-Mobile":           "?1",
+		"Sec-CH-UA-Model":            "SM-S928B",
+		"Sec-CH-UA-Platform":         "Android",
+		"Sec-CH-UA-Platform-Version": "14.0.0",
+	}
+
+	// different case variants for the same header names
+	caseVariants := []map[string]string{
+		// canonical case
+		headerValues,
+		// all lowercase
+		{
+			"user-agent":                  headerValues["User-Agent"],
+			"sec-ch-ua":                   headerValues["Sec-CH-UA"],
+			"sec-ch-ua-full-version-list": headerValues["Sec-CH-UA-Full-Version-List"],
+			"sec-ch-ua-mobile":            headerValues["Sec-CH-UA-Mobile"],
+			"sec-ch-ua-model":             headerValues["Sec-CH-UA-Model"],
+			"sec-ch-ua-platform":          headerValues["Sec-CH-UA-Platform"],
+			"sec-ch-ua-platform-version":  headerValues["Sec-CH-UA-Platform-Version"],
+		},
+		// all uppercase
+		{
+			"USER-AGENT":                  headerValues["User-Agent"],
+			"SEC-CH-UA":                   headerValues["Sec-CH-UA"],
+			"SEC-CH-UA-FULL-VERSION-LIST": headerValues["Sec-CH-UA-Full-Version-List"],
+			"SEC-CH-UA-MOBILE":            headerValues["Sec-CH-UA-Mobile"],
+			"SEC-CH-UA-MODEL":             headerValues["Sec-CH-UA-Model"],
+			"SEC-CH-UA-PLATFORM":          headerValues["Sec-CH-UA-Platform"],
+			"SEC-CH-UA-PLATFORM-VERSION":  headerValues["Sec-CH-UA-Platform-Version"],
+		},
+		// mixed case
+		{
+			"uSeR-aGeNt":                  headerValues["User-Agent"],
+			"sEc-cH-uA":                  headerValues["Sec-CH-UA"],
+			"sEc-cH-uA-fUlL-vErSiOn-lIsT": headerValues["Sec-CH-UA-Full-Version-List"],
+			"sEc-cH-uA-mObIlE":           headerValues["Sec-CH-UA-Mobile"],
+			"sEc-cH-uA-mOdEl":            headerValues["Sec-CH-UA-Model"],
+			"sEc-cH-uA-pLaTfOrM":         headerValues["Sec-CH-UA-Platform"],
+			"sEc-cH-uA-pLaTfOrM-vErSiOn": headerValues["Sec-CH-UA-Platform-Version"],
+		},
+	}
+
+	// perform lookup with the canonical case to get the reference result
+	refDevice, err := wengine.LookupWithImportantHeaderMap(caseVariants[0])
+	require.NoError(t, err)
+	refDeviceID, _ := refDevice.GetDeviceID()
+	refModelName, _ := refDevice.GetStaticCap("model_name")
+	refBrowser, _ := refDevice.GetVirtualCap("advertised_browser")
+	refDevice.Destroy()
+
+	caseLabels := []string{"canonical", "lowercase", "uppercase", "mixed"}
+
+	// verify that all case variants produce identical results
+	for i := 1; i < len(caseVariants); i++ {
+		device, err := wengine.LookupWithImportantHeaderMap(caseVariants[i])
+		require.NoErrorf(t, err, "case variant %s: lookup error", caseLabels[i])
+
+		deviceID, _ := device.GetDeviceID()
+		modelName, _ := device.GetStaticCap("model_name")
+		browser, _ := device.GetVirtualCap("advertised_browser")
+
+		assert.Equalf(t, refDeviceID, deviceID,
+			"case variant %s: device ID mismatch", caseLabels[i])
+		assert.Equalf(t, refModelName, modelName,
+			"case variant %s: model_name mismatch", caseLabels[i])
+		assert.Equalf(t, refBrowser, browser,
+			"case variant %s: advertised_browser mismatch", caseLabels[i])
+
+		device.Destroy()
+	}
+}
+
 func Test_LookupDeviceIDWithRequest(t *testing.T) {
 
 	wengine := fixtureCreateEngine(t)

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -1735,7 +1735,20 @@ func TestGetVirtualCaps(t *testing.T) {
 }
 
 func Test_ORTB2GetDevicetype(t *testing.T) {
-	wengine := fixtureCreateEngine(t)
+	var wengine *wurfl.Wurfl
+
+	URL := os.Getenv("SM_UPDATER_DATA_URL_ORTB2")
+	if URL != "" {
+		err := wurfl.Download(URL, ".")
+		require.NoError(t, err)
+		defer os.Remove("wurfl.zip")
+
+		var createErr error
+		wengine, createErr = wurfl.Create("./wurfl.zip", nil, nil, -1, wurfl.WurflCacheProviderLru, "100000")
+		require.NoError(t, createErr)
+	} else {
+		wengine = fixtureCreateEngine(t)
+	}
 	require.NotNil(t, wengine)
 	defer wengine.Destroy()
 
@@ -1800,7 +1813,7 @@ func Test_ORTB2GetDevicetype(t *testing.T) {
 		},
 		{
 			name:     "Console",
-			ua:       "Mozilla/5.0 (PlayStation Vita 3.73) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2 VTE/3.73",
+			ua:       "Mozilla/5.0 (PlayStation 5/SmartTV) AppleWebKit/605.1.15 (KHTML, like Gecko)",
 			expected: wurfl.ORTB2DeviceTypeConnectedDevice,
 		},
 	}

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -1295,13 +1296,16 @@ func TestDownloadJira1236(t *testing.T) {
 		t.Skip("SM_UPDATER_DATA_URL environment var not set")
 	}
 
+	// Use a dedicated temp directory to avoid conflicts with other tests
+	tempDir := t.TempDir()
+
 	// Copy evaluation wurfl.zip installed with libwurfl here
 	// this file could be under /usr/share/wurfl or /usr/local/share/wurfl depending on the system
 	srcPath := "/usr/share/wurfl/wurfl.zip"
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
 		srcPath = "/usr/local/share/wurfl/wurfl.zip"
 	}
-	destPath := "wurfl.zip"
+	destPath := filepath.Join(tempDir, "wurfl.zip")
 
 	err := copyFile(srcPath, destPath)
 	if err != nil {
@@ -1321,20 +1325,16 @@ func TestDownloadJira1236(t *testing.T) {
 	}
 
 	// Create the engine with eval version, the capfilter makes the engine creation fail
-	_, err = wurfl.Create("wurfl.zip", nil, capfilter, -1, wurfl.WurflCacheProviderLru, "100000")
+	_, err = wurfl.Create(destPath, nil, capfilter, -1, wurfl.WurflCacheProviderLru, "100000")
 
 	assert.ErrorIs(t, err, wurfl.ErrCantLoadCapabilityNotFound)
 
 	// Now download first a fresh wurfl.zip, and then create the engine
-	err = wurfl.Download(URL, ".")
+	err = wurfl.Download(URL, tempDir)
 	require.NoError(t, err)
 
-	_, err = wurfl.Create("wurfl.zip", nil, capfilter, -1, wurfl.WurflCacheProviderLru, "100000")
+	_, err = wurfl.Create(destPath, nil, capfilter, -1, wurfl.WurflCacheProviderLru, "100000")
 	require.NoError(t, err)
-
-	// Remove local wurfl.zip
-	err = os.Remove("wurfl.zip")
-	assert.NoError(t, err)
 }
 
 // TestDownload tests the Download function of the wurfl package. It creates a temporary
@@ -1739,12 +1739,14 @@ func Test_ORTB2GetDevicetype(t *testing.T) {
 
 	URL := os.Getenv("SM_UPDATER_DATA_URL_ORTB2")
 	if URL != "" {
-		err := wurfl.Download(URL, ".")
+		// Use a dedicated temp directory to avoid conflicts with other tests
+		tempDir := t.TempDir()
+		err := wurfl.Download(URL, tempDir)
 		require.NoError(t, err)
-		defer os.Remove("wurfl.zip")
 
+		wurflPath := filepath.Join(tempDir, "wurfl.zip")
 		var createErr error
-		wengine, createErr = wurfl.Create("./wurfl.zip", nil, nil, -1, wurfl.WurflCacheProviderLru, "100000")
+		wengine, createErr = wurfl.Create(wurflPath, nil, nil, -1, wurfl.WurflCacheProviderLru, "100000")
 		require.NoError(t, createErr)
 	} else {
 		wengine = fixtureCreateEngine(t)

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -1794,6 +1794,11 @@ func Test_ORTB2GetDevicetype(t *testing.T) {
 			expected: wurfl.ORTB2DeviceTypePersonalComputer,
 		},
 		{
+			name:     "iPhone",
+			ua:       "Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Mobile/15E148 Safari/604.1",
+			expected: wurfl.ORTB2DeviceTypePhone,
+		},
+		{
 			name:     "Console",
 			ua:       "Mozilla/5.0 (PlayStation Vita 3.73) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2 VTE/3.73",
 			expected: wurfl.ORTB2DeviceTypeConnectedDevice,

--- a/wurfl_test.go
+++ b/wurfl_test.go
@@ -616,6 +616,40 @@ func Test_LookupDeviceIDWithRequest(t *testing.T) {
 	deviceIHM.Destroy()
 }
 
+func Test_LookupDeviceIDWithRequestCaseInsensitiveHeaders(t *testing.T) {
+
+	wengine := fixtureCreateEngine(t)
+	require.NotNil(t, wengine)
+	defer wengine.Destroy()
+
+	// User-Agent
+	UserAgent := "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/135.0.0.0 Mobile Safari/537.36"
+	UADevice, err := wengine.LookupUserAgent(UserAgent)
+	assert.NoErrorf(t, err, "LookupUserAgent returned an error: %s", err)
+	UADeviceID, _ := UADevice.GetDeviceID()
+	UADeviceAdvertisedOSVersion, _ := UADevice.GetVirtualCap("advertised_device_os_version")
+
+	// create http.Request and lookup using headers
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("User-AgeNT", UserAgent)
+	req.Header.Add("Accept", "*/*")
+	req.Header.Add("SEc-Ch-UA", `"Android WebView";v="135", "Not-A.Brand";v="8", "Chromium";v="135"`)
+	req.Header.Add("Sec-Ch-Ua-MObiLe", "?1")
+	req.Header.Add("Sec-Ch-Ua-PlatFORM", "Android")
+	req.Header.Add("Sec-Ch-Ua-PlatFORM-VERsIOn", "12")
+
+	reqDevice, err := wengine.LookupDeviceIDWithRequest(UADeviceID, req)
+	assert.NoErrorf(t, err, "LookupDeviceIDWithRequest returned an error: %s", err)
+	reqDeviceID, _ := reqDevice.GetDeviceID()
+	reqDeviceAdvertisedOSVersion, _ := reqDevice.GetVirtualCap("advertised_device_os_version")
+	assert.Equal(t, UADeviceID, reqDeviceID)
+	// If case insensitivity is not working, the lookup with request will not find the same advertised_device_os_version vcap will be different (12 instead of 10)
+	assert.NotEqual(t, UADeviceAdvertisedOSVersion, reqDeviceAdvertisedOSVersion)
+
+	UADevice.Destroy()
+	reqDevice.Destroy()
+}
+
 func TestWurfl_UpdaterRunonce(t *testing.T) {
 	var wurflZip string
 


### PR DESCRIPTION
## Summary

- **Trie-based case-insensitive header lookup**: Introduces a `headerTrie` data structure that maps HTTP header names to pre-allocated C strings. This replaces per-call `C.CString()` allocations for header names in `LookupWithImportantHeaderMap` and `LookupDeviceIDWithImportantHeaderMap`.
- **Case folding via bit OR-ing**: Both `set()` and `get()` OR each byte with `0x20`, converting ASCII uppercase to lowercase inline during traversal to avoid `strings.ToLower()`.
- **C.free safety improvements**: Moved several `C.free` calls to use `defer` for consistency and to prevent potential leaks on early-return error paths (`Create`, `LookupDeviceIDWithRequest`, `LookupDeviceIDWithImportantHeaderMap`).